### PR TITLE
Renamed AbstractMap/Seq -> ComparableMap/Seq

### DIFF
--- a/checkstyle.xml
+++ b/checkstyle.xml
@@ -255,7 +255,6 @@
             <property name="allowedAbbreviations" value="IT"/>
             <property name="allowedAbbreviationLength" value="1"/>
         </module>
-        <module name="AbstractClassName"/>
         <module name="ClassTypeParameterName"/>
         <module name="ConstantName"/>
         <module name="LocalFinalVariableName">

--- a/src/main/java/com/amihaiemil/eoyaml/ComparableYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ComparableYamlMapping.java
@@ -31,13 +31,17 @@ import java.util.Iterator;
 import java.util.Set;
 
 /**
- * AbstractYamlMapping implementing methods which should be the same across
- * all final implementations of YamlMapping.
+ * Comparable YamlMapping implementing equals, hashcode and compareTo methods.
+ * <br><br>
+ * These methods should be default methods on the interface,
+ * but we are not allowed to have default implementations of java.lang.Object
+ * methods.
+ * 
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  */
-abstract class AbstractYamlMapping implements YamlMapping {
+abstract class ComparableYamlMapping implements YamlMapping {
 
     @Override
     public int hashCode() {
@@ -95,7 +99,7 @@ abstract class AbstractYamlMapping implements YamlMapping {
         if (other == null || !(other instanceof YamlMapping)) {
             result = 1;
         } else if (this != other) {
-            final AbstractYamlMapping map = (AbstractYamlMapping) other;
+            final ComparableYamlMapping map = (ComparableYamlMapping) other;
             final Set<YamlNode> keys = this.keys();
             final Set<YamlNode> otherKeys = map.keys();
             if(keys.size() > otherKeys.size()) {

--- a/src/main/java/com/amihaiemil/eoyaml/ComparableYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ComparableYamlSequence.java
@@ -31,13 +31,17 @@ import java.util.Collection;
 import java.util.Iterator;
 
 /**
- * AbstractYamlSequence implementing methods which should be the same across 
- * all final implementations of YamlSequence.
+ * Comparable YamlSequence implementing equals, hashcode and compareTo methods.
+ * <br><br>
+ * These methods should be default methods on the interface,
+ * but we are not allowed to have default implementations of java.lang.Object
+ * methods.
+ * 
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  */
-abstract class AbstractYamlSequence implements YamlSequence {
+abstract class ComparableYamlSequence implements YamlSequence {
     
     @Override
     public int hashCode() {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -39,7 +39,7 @@ import java.util.Set;
  * @version $Id$
  * @since 1.0.0
  */
-final class ReadYamlMapping extends AbstractYamlMapping {
+final class ReadYamlMapping extends ComparableYamlMapping {
 
     /**
      * Lines read.

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -11,7 +11,7 @@ import java.util.List;
  * @version $Id$
  * @since 1.0.0
  */
-final class ReadYamlSequence extends AbstractYamlSequence {
+final class ReadYamlSequence extends ComparableYamlSequence {
 
     /**
      * Lines read.

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -40,7 +40,7 @@ import java.util.TreeMap;
  * @since 1.0.0
  * @see http://yaml.org/spec/1.2/spec.html#mapping//
  */
-final class RtYamlMapping extends AbstractYamlMapping {
+final class RtYamlMapping extends ComparableYamlMapping {
 
     /**
      * Key:value tree map (ordered keys).

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
@@ -39,7 +39,7 @@ import java.util.List;
  * @since 1.0.0
  * @see http://yaml.org/spec/1.2/spec.html#sequence//
  */
-final class RtYamlSequence extends AbstractYamlSequence {
+final class RtYamlSequence extends ComparableYamlSequence {
 
     /**
      * Nodes in this sequence.

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -41,18 +41,18 @@ import java.util.Set;
  * @version $Id$
  * @since 1.0.0
  */
-public final class StrictYamlMapping extends AbstractYamlMapping {
+public final class StrictYamlMapping extends ComparableYamlMapping {
 
     /**
      * Original YamlMapping.
      */
-    private AbstractYamlMapping decorated;
+    private YamlMapping decorated;
 
     /**
      * Ctor.
      * @param decorated Original YamlMapping
      */
-    public StrictYamlMapping(final AbstractYamlMapping decorated) {
+    public StrictYamlMapping(final YamlMapping decorated) {
         this.decorated = decorated;
     }
 

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
@@ -39,7 +39,7 @@ import java.util.Iterator;
  * @version $Id$
  * @since 1.0.0
  */
-public final class StrictYamlSequence extends AbstractYamlSequence {
+public final class StrictYamlSequence extends ComparableYamlSequence {
 
     /**
      * Original YamlSequence.

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -81,7 +81,7 @@ public final class StrictYamlMappingTest {
      */
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullMapping() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         Mockito.when(origin.yamlMapping("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.yamlMapping("key");
@@ -93,7 +93,7 @@ public final class StrictYamlMappingTest {
      */
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullSequence() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         Mockito.when(origin.yamlSequence("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.yamlSequence("key");
@@ -105,7 +105,7 @@ public final class StrictYamlMappingTest {
      */
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullString() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         Mockito.when(origin.string("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.string("key");
@@ -116,7 +116,7 @@ public final class StrictYamlMappingTest {
      */
     @Test
     public void returnsMapping() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlMapping found = Mockito.mock(YamlMapping.class);
         YamlNode key = new Scalar("key");
         Mockito.when(origin.yamlMapping(key)).thenReturn(found);
@@ -131,7 +131,7 @@ public final class StrictYamlMappingTest {
      */
     @Test
     public void returnsSequence() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlSequence found = Mockito.mock(YamlSequence.class);
         YamlNode key = new Scalar("key");
         Mockito.when(origin.yamlSequence(key)).thenReturn(found);
@@ -146,7 +146,7 @@ public final class StrictYamlMappingTest {
      */
     @Test
     public void returnsString() {
-        AbstractYamlMapping origin = Mockito.mock(AbstractYamlMapping.class);
+        YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlNode key = new Scalar("key");
         Mockito.when(origin.string(key)).thenReturn("found");
         YamlMapping strict = new StrictYamlMapping(origin);


### PR DESCRIPTION
PR for #158 
Renamed classes AbstractYamlMapping and AbstractYamlSequence to ComparableYamlMapping and ComparableYamlSequence respectively. 

Also made StrictYamlMapping to work with YamlMapping instead of Abstract(Comparable)YamlMapping.