### PR TITLE
Convenience Type-Casting methods

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -244,10 +244,10 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     float value = Double.parseDouble(map.string(...));
+     *     double value = Double.parseDouble(map.string(...));
      * </pre>
      * @param key The key of the value.
-     * @return Found float or -1.0 if there is no value for the key,
+     * @return Found double or -1.0 if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable double.
@@ -261,10 +261,10 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     float value = Double.parseDouble(map.string(...));
+     *     double value = Double.parseDouble(map.string(...));
      * </pre>
      * @param key The key of the value.
-     * @return Found integer or -1.0 if there is no value for the key,
+     * @return Found double or -1.0 if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable double.
@@ -282,10 +282,10 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     float value = Long.parseLong(map.string(...));
+     *     long value = Long.parseLong(map.string(...));
      * </pre>
      * @param key The key of the value.
-     * @return Found float or -1L if there is no value for the key,
+     * @return Found long or -1L if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable double.
@@ -299,10 +299,10 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     float value = Long.parseLong(map.string(...));
+     *     long value = Long.parseLong(map.string(...));
      * </pre>
      * @param key The key of the value.
-     * @return Found integer or -1L if there is no value for the key,
+     * @return Found long or -1L if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable double.
@@ -320,7 +320,7 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     LocalDateTime dateTime = LocalDate.parse(map.string(...));
+     *     LocalDate dateTime = LocalDate.parse(map.string(...));
      * </pre>
      * @param key The key of the value.
      * @return Found LocalDate or null if there is no value for the key,
@@ -336,7 +336,7 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     LocalDateTime dateTime = LocalDate.parse(map.string(...));
+     *     LocalDate dateTime = LocalDate.parse(map.string(...));
      * </pre>
      * @param key The key of the value.
      * @return Found LocalDate or null if there is no value for the key,

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -226,7 +226,7 @@ public interface YamlMapping extends YamlNode {
      *     float value = Float.parseFloat(map.string(...));
      * </pre>
      * @param key The key of the value.
-     * @return Found integer or -1 if there is no value for the key,
+     * @return Found float or -1 if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable float.
@@ -288,7 +288,7 @@ public interface YamlMapping extends YamlNode {
      * @return Found long or -1L if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable double.
+     *  is not a parsable long.
      */
     default long longNumber(final String key) {
         return this.longNumber(new Scalar(key));
@@ -305,7 +305,7 @@ public interface YamlMapping extends YamlNode {
      * @return Found long or -1L if there is no value for the key,
      *  or the value is not a Scalar.
      * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable double.
+     *  is not a parsable long.
      */
     default long longNumber(final YamlNode key) {
         final YamlNode value = this.value(key);
@@ -320,7 +320,7 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     LocalDate dateTime = LocalDate.parse(map.string(...));
+     *     LocalDate date = LocalDate.parse(map.string(...));
      * </pre>
      * @param key The key of the value.
      * @return Found LocalDate or null if there is no value for the key,
@@ -336,7 +336,7 @@ public interface YamlMapping extends YamlNode {
      * from this map. It is equivalent to:
      * <pre>
      *     YamlMapping map = ...;
-     *     LocalDate dateTime = LocalDate.parse(map.string(...));
+     *     LocalDate date = LocalDate.parse(map.string(...));
      * </pre>
      * @param key The key of the value.
      * @return Found LocalDate or null if there is no value for the key,

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -27,11 +27,15 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Set;
 
 /**
  * A Yaml mapping.
  * @checkstyle ExecutableStatementCount (300 lines)
+ * @checkstyle ReturnCount (400 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -157,5 +161,229 @@ public interface YamlMapping extends YamlNode {
             printed = printed.substring(0, printed.length() - 1);
         }
         return printed;
+    }
+    
+    /**
+     * Convenience method to directly read an integer value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     int value = Integer.parseInt(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found integer or -1 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable integer.
+     */
+    default int integer(final String key) {
+        return this.integer(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read an integer value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     int value = Integer.parseInt(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found integer or -1 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable integer.
+     */
+    default int integer(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return Integer.parseInt(((Scalar) value).value());
+        }
+        return -1;
+    }
+    
+    /**
+     * Convenience method to directly read a float value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Float.parseFloat(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found float or -1 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable float.
+     */
+    default float floatNumber(final String key) {
+        return this.floatNumber(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read a float value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Float.parseFloat(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found integer or -1 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable float.
+     */
+    default float floatNumber(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return Float.parseFloat(((Scalar) value).value());
+        }
+        return -1;
+    }
+    
+    /**
+     * Convenience method to directly read a double value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Double.parseDouble(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found float or -1.0 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default double doubleNumber(final String key) {
+        return this.doubleNumber(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read a double value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Double.parseDouble(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found integer or -1.0 if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default double doubleNumber(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return Double.parseDouble(((Scalar) value).value());
+        }
+        return -1.0;
+    }
+    
+    /**
+     * Convenience method to directly read a long value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Long.parseLong(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found float or -1L if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default long longNumber(final String key) {
+        return this.longNumber(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read a long value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     float value = Long.parseLong(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found integer or -1L if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default long longNumber(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return Long.parseLong(((Scalar) value).value());
+        }
+        return -1L;
+    }
+
+    /**
+     * Convenience method to directly read a LocalDate value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     LocalDateTime dateTime = LocalDate.parse(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found LocalDate or null if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDate date(final String key) {
+        return this.date(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read a LocalDate value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     LocalDateTime dateTime = LocalDate.parse(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found LocalDate or null if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDate date(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return LocalDate.parse(((Scalar) value).value());
+        }
+        return null;
+    }
+    
+    /**
+     * Convenience method to directly read a LocalDateTime value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     LocalDateTime dateTime = LocalDateTime.parse(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found LocalDateTime or null if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDateTime dateTime(final String key) {
+        return this.dateTime(new Scalar(key));
+    }
+    
+    /**
+     * Convenience method to directly read a LocalDateTime value
+     * from this map. It is equivalent to:
+     * <pre>
+     *     YamlMapping map = ...;
+     *     LocalDateTime dateTime = LocalDateTime.parse(map.string(...));
+     * </pre>
+     * @param key The key of the value.
+     * @return Found LocalDateTime or null if there is no value for the key,
+     *  or the value is not a Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDateTime dateTime(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        if(value != null && value instanceof Scalar) {
+            return LocalDateTime.parse(((Scalar) value).value());
+        }
+        return null;
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
@@ -27,10 +27,14 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeParseException;
 import java.util.Iterator;
 
 /**
  * A Yaml sequence.
+ * @checkstyle ReturnCount (400 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -47,21 +51,24 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
     /**
      * Get the Yaml mapping  from the given index.
      * @param index Integer index.
-     * @return Yaml mapping
+     * @return Yaml mapping or null if nothing is found,
+     *  or if the found value is not a YamlMapping.
      */
     YamlMapping yamlMapping(final int index);
 
     /**
-     * Get the Yaml sequence  from the given index.
+     * Get the Yaml sequence from the given index.
      * @param index Integer index.
-     * @return Yaml sequence
+     * @return Yaml sequence or null if nothing is found,
+     *  or if the found value is not a YamlSequence.
      */
     YamlSequence yamlSequence(final int index);
 
     /**
      * Get the String from the given index.
      * @param index Integer index.
-     * @return String
+     * @return String or null if nothing is found, or
+     *  if the found YamlNode is not a Scalar.
      */
     String string(final int index);
 
@@ -109,5 +116,129 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
             printed = printed.substring(0, printed.length() - 1);
         }
         return printed;
+    }
+    
+    /**
+     * Convenience method to directly read an integer value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     int value = Integer.parseInt(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found integer or -1 if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable integer.
+     */
+    default int integer(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return Integer.parseInt(value);
+        }
+        return -1;
+    }
+    
+    /**
+     * Convenience method to directly read a float value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     float value = Float.parseFloat(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found integer or -1 if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable float.
+     */
+    default float floatNumber(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return Float.parseFloat(value);
+        }
+        return -1;
+    }
+    
+    /**
+     * Convenience method to directly read a double value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     double value = Double.parseDouble(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found integer or -1.0 if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default double doubleNumber(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return Double.parseDouble(value);
+        }
+        return -1.0;
+    }
+    
+    /**
+     * Convenience method to directly read a long value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     long value = Long.parseLong(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found integer or -1L if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws NumberFormatException - if the Scalar value
+     *  is not a parsable double.
+     */
+    default long longNumber(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return Long.parseLong(value);
+        }
+        return -1L;
+    }
+
+    /**
+     * Convenience method to directly read a LocalDate value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     LocalDate dateTime = LocalDate.parse(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found LocalDate or null if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDate date(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return LocalDate.parse(value);
+        }
+        return null;
+    }
+    
+    /**
+     * Convenience method to directly read a LocalDateTime value
+     * from this sequence. It is equivalent to:
+     * <pre>
+     *     YamlSequence sequence = ...;
+     *     LocalDateTime dateTime = LocalDateTime.parse(sequence.string(...));
+     * </pre>
+     * @param index The index of the value.
+     * @return Found LocalDateTime or null if there is no value found or it
+     *  the value is not a string Scalar.
+     * @throws DateTimeParseException - if the Scalar value cannot be parsed.
+     */
+    default LocalDateTime dateTime(final int index) {
+        final String value = this.string(index);
+        if(value != null && !value.isEmpty()) {
+            return LocalDateTime.parse(value);
+        }
+        return null;
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
@@ -51,24 +51,21 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
     /**
      * Get the Yaml mapping  from the given index.
      * @param index Integer index.
-     * @return Yaml mapping or null if nothing is found,
-     *  or if the found value is not a YamlMapping.
+     * @return Yaml mapping.
      */
     YamlMapping yamlMapping(final int index);
 
     /**
      * Get the Yaml sequence from the given index.
      * @param index Integer index.
-     * @return Yaml sequence or null if nothing is found,
-     *  or if the found value is not a YamlSequence.
+     * @return Yaml sequence.
      */
     YamlSequence yamlSequence(final int index);
 
     /**
      * Get the String from the given index.
      * @param index Integer index.
-     * @return String or null if nothing is found, or
-     *  if the found YamlNode is not a Scalar.
+     * @return String.
      */
     String string(final int index);
 
@@ -126,8 +123,7 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     int value = Integer.parseInt(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found integer or -1 if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found integer.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable integer.
      */
@@ -147,8 +143,7 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     float value = Float.parseFloat(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found integer or -1 if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found float.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable float.
      */
@@ -168,8 +163,7 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     double value = Double.parseDouble(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found integer or -1.0 if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found double.
      * @throws NumberFormatException - if the Scalar value
      *  is not a parsable double.
      */
@@ -189,10 +183,9 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     long value = Long.parseLong(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found integer or -1L if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found long.
      * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable double.
+     *  is not a parsable long.
      */
     default long longNumber(final int index) {
         final String value = this.string(index);
@@ -210,8 +203,7 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     LocalDate dateTime = LocalDate.parse(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found LocalDate or null if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found LocalDate.
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDate date(final int index) {
@@ -230,8 +222,7 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      *     LocalDateTime dateTime = LocalDateTime.parse(sequence.string(...));
      * </pre>
      * @param index The index of the value.
-     * @return Found LocalDateTime or null if there is no value found or it
-     *  the value is not a string Scalar.
+     * @return Found LocalDateTime.
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDateTime dateTime(final int index) {

--- a/src/test/java/com/amihaiemil/eoyaml/YamlMappingTypeCastingTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlMappingTypeCastingTestCase.java
@@ -1,0 +1,140 @@
+/**
+ * Copyright (c) 2016-2020, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.eoyaml;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit tests for the convenience type-casting methods
+ * in {@link YamlMapping}.
+ * @checkstyle JavadocMethod (300 lines)
+ * @author Mihai Andronache
+ * @version $Id$
+ * @since 3.1.1
+ */
+public final class YamlMappingTypeCastingTestCase {
+
+    @Test
+    public void returnsInteger() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.integer("integer"),
+            Matchers.is(123)
+        );
+        MatcherAssert.assertThat(
+            mapping.integer("missing_integer"),
+            Matchers.is(-1)
+        );
+    }
+    
+    @Test
+    public void returnsFloat() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.floatNumber("float"),
+            Matchers.is(3.54F)
+        );
+        MatcherAssert.assertThat(
+            mapping.floatNumber("missing_float"),
+            Matchers.is(-1F)
+        );
+    }
+    
+    @Test
+    public void returnsDouble() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.doubleNumber("double"),
+            Matchers.is(2.05)
+        );
+        MatcherAssert.assertThat(
+            mapping.integer("missing_double"),
+            Matchers.is(-1)
+        );
+    }
+    
+    @Test
+    public void returnsLong() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.longNumber("long"),
+            Matchers.is(32165498L)
+        );
+        MatcherAssert.assertThat(
+            mapping.longNumber("missing_long"),
+            Matchers.is(-1L)
+        );
+    }
+    
+    @Test
+    public void returnsDate() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.date("localDate"),
+            Matchers.is(LocalDate.parse("2007-12-03"))
+        );
+        MatcherAssert.assertThat(
+            mapping.date("missing_localDate"),
+            Matchers.nullValue()
+        );
+    }
+    
+    @Test
+    public void returnsDateTime() {
+        final YamlMapping mapping = this.mapping();
+        MatcherAssert.assertThat(
+            mapping.dateTime("localDateTime"),
+            Matchers.is(LocalDateTime.parse("2007-12-03T10:15:30"))
+        );
+        MatcherAssert.assertThat(
+            mapping.dateTime("missing_localDateTime"),
+            Matchers.nullValue()
+        );
+    }
+    
+    /**
+     * Get a YamlMapping for test.
+     * @return YamlMapping.
+     */
+    private YamlMapping mapping() {
+        YamlMapping mapping = Yaml.createYamlMappingBuilder()
+            .add("integer", "123")
+            .add("float", "3.54")
+            .add("double", "2.05")
+            .add("long", "32165498")
+            .add("localDate", "2007-12-03")
+            .add("localDateTime", "2007-12-03T10:15:30")
+            .build();
+        return mapping;
+    }
+}

--- a/src/test/java/com/amihaiemil/eoyaml/YamlSequenceTypeCastingTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlSequenceTypeCastingTestCase.java
@@ -1,0 +1,110 @@
+/**
+ * Copyright (c) 2016-2020, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.eoyaml;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+/**
+ * Unit tests for the convenience type-casting methods
+ * in {@link YamlSequence}.
+ * @checkstyle JavadocMethod (300 lines)
+ * @author Mihai Andronache
+ * @version $Id$
+ * @since 3.1.1
+ */
+public final class YamlSequenceTypeCastingTestCase {
+
+    @Test
+    public void returnsInteger() {
+        MatcherAssert.assertThat(
+            this.sequence().integer(0),
+            Matchers.is(123)
+        );
+    }
+    
+    @Test
+    public void returnsFloat() {
+        MatcherAssert.assertThat(
+            this.sequence().floatNumber(1),
+            Matchers.is(3.54F)
+        );
+    }
+    
+    @Test
+    public void returnsDouble() {
+        MatcherAssert.assertThat(
+            this.sequence().doubleNumber(2),
+            Matchers.is(2.05)
+        );
+    }
+    
+    @Test
+    public void returnsLong() {
+        MatcherAssert.assertThat(
+            this.sequence().longNumber(3),
+            Matchers.is(32165498L)
+        );
+    }
+    
+    @Test
+    public void returnsDate() {
+        MatcherAssert.assertThat(
+            this.sequence().date(4),
+            Matchers.is(LocalDate.parse("2007-12-03"))
+        );
+    }
+    
+    @Test
+    public void returnsDateTime() {
+        MatcherAssert.assertThat(
+            this.sequence().dateTime(5),
+            Matchers.is(LocalDateTime.parse("2007-12-03T10:15:30"))
+        );
+    }
+    
+    /**
+     * Get a YamlSequence for test.
+     * @return YamlSequence.
+     */
+    private YamlSequence sequence() {
+        YamlSequence sequence = Yaml.createYamlSequenceBuilder()
+            .add("123")
+            .add("3.54")
+            .add("2.05")
+            .add("32165498")
+            .add("2007-12-03")
+            .add("2007-12-03T10:15:30")
+            .build();
+        return sequence;
+    }
+}


### PR DESCRIPTION
fixes #151 
Convenience Type-Casting Methods for both YamlMapping and YamlSequence. We offer type-casting for: 

* int
* float
* double
* long
* LocalDate
* LocalDateTime.