### PR TITLE
Scalar redesigned

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -68,7 +68,7 @@ final class AllYamlLines implements YamlLines {
     public Collection<YamlLine> lines() {
         return this.lines;
     }
-    
+
     @Override
     public YamlNode toYamlNode(final YamlLine prev) {
         final String trimmed = prev.trimmed();
@@ -106,11 +106,11 @@ final class AllYamlLines implements YamlLines {
                     node = new ReadYamlSequence(this);
                 }
                 break;
-            case Nested.PIPED_SCALAR:
-                node = new ReadPipeScalar(this);
+            case Nested.LITERAL_BLOCK_SCALAR:
+                node = new ReadLiteralBlockScalar(this);
                 break;
-            case Nested.POINTED_SCALAR:
-                node = new ReadPointedScalar(this);
+            case Nested.FOLDED_BLOCK_SCALAR:
+                node = new ReadFoldedBlockScalar(this);
                 break;
             default:
                 node = null;
@@ -118,5 +118,5 @@ final class AllYamlLines implements YamlLines {
         }
         return node;
     }
-    
+
 }

--- a/src/main/java/com/amihaiemil/eoyaml/BuiltPlainScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BuiltPlainScalar.java
@@ -31,40 +31,35 @@ import java.util.Collection;
 import java.util.LinkedList;
 
 /**
- * Read Yaml Scalar when previous yaml line ends with '|' character.
- * @author Sherif Waly (sherifwaly95@gmail.com)
+ * YAML Plain scalar to be used when building a YAML, via
+ * one of the builders.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.2
- *
+ * @since 1.0.0
+ * @see http://yaml.org/spec/1.2/spec.html#scalar//
  */
-final class ReadPipeScalar implements YamlNode {
+final class BuiltPlainScalar extends ComparableScalar {
 
     /**
-     * Lines to be represented as a wrapped scalar.
+     * This scalar's value.
      */
-    private YamlLines lines;
+    private String value;
 
     /**
      * Ctor.
-     * @param lines Given lines to represent.
+     * @param value Given value for this scalar.
      */
-    ReadPipeScalar(final YamlLines lines) {
-        this.lines = lines;
+    BuiltPlainScalar(final String value) {
+        this.value = value;
     }
 
+    /**
+     * Value of this scalar.
+     * @return Value of type T.
+     */
     @Override
-    public int compareTo(final YamlNode other) {
-        int result = -1;
-        if (this == other) {
-            result = 0;
-        } else if (other == null) {
-            result = 1;
-        } else if (other instanceof BuiltPlainScalar) {
-            result = this.value().compareTo(((BuiltPlainScalar) other).value());
-        } else if (other instanceof ReadPipeScalar) {
-            result = this.value().compareTo(((ReadPipeScalar) other).value());
-        }
-        return result;
+    public String value() {
+        return this.value;
     }
 
     @Override
@@ -73,38 +68,19 @@ final class ReadPipeScalar implements YamlNode {
     }
 
     @Override
-    public String indent(final int indentation) {
-        StringBuilder printed = new StringBuilder();
-        for(final YamlLine line: this.lines) {
-            int spaces = indentation;
-            while (spaces > 0) {
-                printed.append(" ");
-                spaces--;
-            }
-            printed.append(line.trimmed());
-            printed.append('\n');
-        }
-        printed.delete(printed.length()-1, printed.length());
-        return printed.toString();
-    }
-
-    /**
-     * Value of this scalar.
-     * @return String
-     */
-    public String value() {
-        StringBuilder builder = new StringBuilder();
-        for(final YamlLine line: this.lines) {
-            builder.append(line.trimmed());
-            builder.append('\n');
-        }
-        builder.delete(builder.length()-1, builder.length());
-        return builder.toString();
+    public String toString() {
+        return this.indent(0);
     }
 
     @Override
-    public String toString() {
-        return this.indent(0);
+    public String indent(final int indentation) {
+        int spaces = indentation;
+        StringBuilder printed = new StringBuilder();
+        while (spaces > 0) {
+            printed.append(" ");
+            spaces--;
+        }
+        return printed.append(this.value).toString();
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ComparableScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ComparableScalar.java
@@ -39,7 +39,7 @@ package com.amihaiemil.eoyaml;
  * @since 3.1.3
  */
 abstract class ComparableScalar implements Scalar {
-    
+
     /**
      * Equality of two objects.
      * @param other Reference to the right hand Scalar
@@ -90,5 +90,10 @@ abstract class ComparableScalar implements Scalar {
             result = this.value().compareTo(((Scalar) other).value());
         }
         return result;
+    }
+
+    @Override
+    public String toString() {
+        return this.indent(0);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ComparableScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ComparableScalar.java
@@ -27,31 +27,58 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
- * Read Yaml Scalar when previous yaml line ends with '|' character.
- * @author Sherif Waly (sherifwaly95@gmail.com)
- * @version $Id$
- * @since 1.0.2
+ * Comparable Yaml Scalar implementing equals, hashcode and compareTo methods.
+ * <br><br>
+ * These methods should be default methods on the interface,
+ * but we are not allowed to have default implementations of java.lang.Object
+ * methods.
  *
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 3.1.3
  */
-final class ReadPipeScalar implements YamlNode {
-
+abstract class ComparableScalar implements Scalar {
+    
     /**
-     * Lines to be represented as a wrapped scalar.
+     * Equality of two objects.
+     * @param other Reference to the right hand Scalar
+     * @return True if object are equal and False if are not.
      */
-    private YamlLines lines;
-
-    /**
-     * Ctor.
-     * @param lines Given lines to represent.
-     */
-    ReadPipeScalar(final YamlLines lines) {
-        this.lines = lines;
+    @Override
+    public boolean equals(final Object other) {
+        final boolean result;
+        if (other == null || !(other instanceof Scalar)) {
+            result = false;
+        } else if (this == other) {
+            result = true;
+        } else {
+            result = this.compareTo((Scalar) other) == 0;
+        }
+        return result;
     }
 
+    /**
+     * Hash Code of this scalar.
+     * @return Value of hashCode() of type int.
+     */
+    @Override
+    public int hashCode() {
+        return this.value().hashCode();
+    }
+
+    /**
+     * Compare this Scalar to another node.<br><br>
+     *
+     * A Scalar is always considered less than a Sequence or a Mapping.<br>
+     * If o is Scalar then their String values are compared lexicographically
+     *
+     * @param other The other AbstractNode.
+     * @return
+     *  a value < 0 if this < o <br>
+     *   0 if this == o or <br>
+     *  a value > 0 if this > o
+     */
     @Override
     public int compareTo(final YamlNode other) {
         int result = -1;
@@ -59,52 +86,9 @@ final class ReadPipeScalar implements YamlNode {
             result = 0;
         } else if (other == null) {
             result = 1;
-        } else if (other instanceof BuiltPlainScalar) {
-            result = this.value().compareTo(((BuiltPlainScalar) other).value());
-        } else if (other instanceof ReadPipeScalar) {
-            result = this.value().compareTo(((ReadPipeScalar) other).value());
+        } else if (other instanceof Scalar) {
+            result = this.value().compareTo(((Scalar) other).value());
         }
         return result;
     }
-
-    @Override
-    public Collection<YamlNode> values() {
-        return new LinkedList<YamlNode>();
-    }
-
-    @Override
-    public String indent(final int indentation) {
-        StringBuilder printed = new StringBuilder();
-        for(final YamlLine line: this.lines) {
-            int spaces = indentation;
-            while (spaces > 0) {
-                printed.append(" ");
-                spaces--;
-            }
-            printed.append(line.trimmed());
-            printed.append('\n');
-        }
-        printed.delete(printed.length()-1, printed.length());
-        return printed.toString();
-    }
-
-    /**
-     * Value of this scalar.
-     * @return String
-     */
-    public String value() {
-        StringBuilder builder = new StringBuilder();
-        for(final YamlLine line: this.lines) {
-            builder.append(line.trimmed());
-            builder.append('\n');
-        }
-        builder.delete(builder.length()-1, builder.length());
-        return builder.toString();
-    }
-
-    @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Nested.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Nested.java
@@ -59,14 +59,14 @@ final class Nested {
      * If this is the last char on a line, it means a pointed wrapped scalar
      * should be nested bellow (see Example 2.15 from YAML spec 1.2).
      */
-    static final String POINTED_SCALAR = ">";
+    static final String FOLDED_BLOCK_SCALAR = ">";
 
     /**
-     * If this is the last char on a line, it means a piped wrapped scalar
+     * If this is the last char on a line, it means a literal block scalar
      * should be nested bellow (all newlines are significant, and
      * taken into account).
      */
-    static final String PIPED_SCALAR = "|";
+    static final String LITERAL_BLOCK_SCALAR = "|";
 
     /**
      * If this is the last char on a line, it means a complex key

--- a/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
@@ -27,18 +27,24 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
- * Read Yaml Scalar when previous yaml line ends with '>' character.
+ * Read Yaml folded block Scalar. This is a Scalar spanning multiple lines.
+ * This Scalar's newlines will be ignored ("folded"), the scalar's value
+ * is a single line of text split in multiple lines for readability.<br><br>
+ * Example of Folded Block Scalar:
+ * <pre>
+ *   folded block scalar: >
+ *     a long line split into
+ *     several short
+ *     lines for readability
+ * </pre>
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.2
  * @todo #109:30m/DEV Refactor the implementation of value() and indent()
  *  methods.
  */
-final class ReadPointedScalar implements YamlNode {
+final class ReadFoldedBlockScalar extends ComparableScalar {
 
     /**
      * Lines to be represented as a wrapped scalar.
@@ -49,31 +55,8 @@ final class ReadPointedScalar implements YamlNode {
      * Ctor.
      * @param lines Given lines to represent.
      */
-    ReadPointedScalar(final YamlLines lines) {
+    ReadFoldedBlockScalar(final YamlLines lines) {
         this.lines = lines;
-    }
-
-    @Override
-    public int compareTo(final YamlNode other) {
-        int result = -1;
-        if (this == other) {
-            result = 0;
-        } else if (other == null) {
-            result = 1;
-        } else if (other instanceof BuiltPlainScalar) {
-            result = this.value().compareTo(((BuiltPlainScalar) other).value());
-        } else if (other instanceof ReadPipeScalar) {
-            result = this.value().compareTo(((ReadPipeScalar) other).value());
-        } else if (other instanceof ReadPointedScalar) {
-            result =
-                this.value().compareTo(((ReadPointedScalar) other).value());
-        }
-        return result;
-    }
-
-    @Override
-    public Collection<YamlNode> values() {
-        return new LinkedList<YamlNode>();
     }
 
     @Override
@@ -140,11 +123,6 @@ final class ReadPointedScalar implements YamlNode {
             }
         }
         return builder.toString();
-    }
-
-    @Override
-    public String toString() {
-        return this.indent(0);
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
@@ -27,17 +27,22 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
- * Read Yaml Scalar when previous yaml line ends with '|' character.
+ * Read Yaml literal block Scalar. This is a Scalar spanning multiple lines.
+ * This Scalar's lines will be treated as separate lines and won't be folded
+ * into a single line. Example of Literal Block Scalar:
+ * <pre>
+ *   literal block scalar: |
+ *     a multiline text
+ *     line two of the scalar
+ *     line three of the scalar
+ * </pre>
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.2
  *
  */
-final class ReadPipeScalar implements YamlNode {
+final class ReadLiteralBlockScalar extends ComparableScalar {
 
     /**
      * Lines to be represented as a wrapped scalar.
@@ -48,28 +53,8 @@ final class ReadPipeScalar implements YamlNode {
      * Ctor.
      * @param lines Given lines to represent.
      */
-    ReadPipeScalar(final YamlLines lines) {
+    ReadLiteralBlockScalar(final YamlLines lines) {
         this.lines = lines;
-    }
-
-    @Override
-    public int compareTo(final YamlNode other) {
-        int result = -1;
-        if (this == other) {
-            result = 0;
-        } else if (other == null) {
-            result = 1;
-        } else if (other instanceof BuiltPlainScalar) {
-            result = this.value().compareTo(((BuiltPlainScalar) other).value());
-        } else if (other instanceof ReadPipeScalar) {
-            result = this.value().compareTo(((ReadPipeScalar) other).value());
-        }
-        return result;
-    }
-
-    @Override
-    public Collection<YamlNode> values() {
-        return new LinkedList<YamlNode>();
     }
 
     @Override
@@ -100,11 +85,6 @@ final class ReadPipeScalar implements YamlNode {
         }
         builder.delete(builder.length()-1, builder.length());
         return builder.toString();
-    }
-
-    @Override
-    public String toString() {
-        return this.indent(0);
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarKey.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarKey.java
@@ -28,18 +28,16 @@
 package com.amihaiemil.eoyaml;
 
 /**
- * A plain scalar value read from a read mapping or a read sequence.
- * @author Mihai Andronace (amihaiemil@gmail.com)
+ * A Scalar key from a ReadYamlMapping.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.3
  */
-final class ReadPlainScalarValue extends ComparableScalar {
+final class ReadPlainScalarKey extends ComparableScalar {
 
     /**
-     * Line where the plain scalar value is supposed to be found.
-     * The Scalar can be either after the ":" character, if this
-     * line is from a mapping, or after the "-" character, if
-     * this line is from a sequence.
+     * Line where the plain scalar key is supposed to be found.
+     * This line should start with "key:".
      */
     private YamlLine line;
 
@@ -47,27 +45,25 @@ final class ReadPlainScalarValue extends ComparableScalar {
      * Constructor.
      * @param line Read YamlLine.
      */
-    ReadPlainScalarValue(final YamlLine line) {
+    ReadPlainScalarKey(final YamlLine line) {
         this.line = line;
     }
 
     @Override
     public String value() {
-        final String value;
         final String trimmed = this.line.trimmed();
-        if(trimmed.startsWith("-") && trimmed.length() > 1) {
-            value = trimmed.substring(trimmed.indexOf('-')+1).trim();
-        } else if(trimmed.contains(":") && !trimmed.endsWith(":")) {
-            value = trimmed.substring(trimmed.indexOf(":") + 1).trim();
-        } else {
-            throw new IllegalStateException(
-                "Missing scalar on line " + (this.line.number() + 1) + ". "
-                + "The line was expected to be either part of a "
-                + "mapping (key: value) or part of a sequence (- value). "
-                + "Instead, the line is: [" + this.line.trimmed() + "]."
-            );
+        if(trimmed.contains(":")) {
+            final String keyPart = trimmed.substring(
+                0, trimmed.indexOf(":")
+            ).trim();
+            if (!keyPart.isEmpty()) {
+                return keyPart;
+            }
         }
-        return value;
+        throw new IllegalStateException(
+            "Expected scalar key on line " + (this.line.number() + 1) + "."
+                + " The line should have the format 'key: value' or 'key:'. "
+                + "Instead, the line is: [" + this.line.trimmed() + "]."
+        );
     }
-
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
@@ -28,34 +28,45 @@
 package com.amihaiemil.eoyaml;
 
 /**
- * YAML Plain scalar to be used when building a YAML, via
- * one of the builders.
- * @author Mihai Andronache (amihaiemil@gmail.com)
+ * A plain scalar value read from a read mapping or a read sequence.
+ * @author Mihai Andronace (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.0
- * @see http://yaml.org/spec/1.2/spec.html#scalar//
+ * @since 3.1.3
  */
-final class BuiltPlainScalar extends ComparableScalar {
+final class ReadPlainScalarValue extends ComparableScalar {
 
     /**
-     * This scalar's value.
+     * Line where the plain scalar value is supposed to be found.
+     * The Scalar can be either after the ":" character, if this
+     * line is from a mapping, or after the "-" character, if
+     * this line is from a sequence.
      */
-    private String value;
+    private YamlLine line;
 
     /**
-     * Ctor.
-     * @param value Given value for this scalar.
+     * Constructor.
+     * @param line Read YamlLine.
      */
-    BuiltPlainScalar(final String value) {
-        this.value = value;
+    ReadPlainScalarValue(final YamlLine line) {
+        this.line = line;
     }
 
-    /**
-     * Value of this scalar.
-     * @return Value of type T.
-     */
     @Override
     public String value() {
-        return this.value;
+        final String value;
+        final String trimmed = this.line.trimmed();
+        if(trimmed.startsWith("-") && trimmed.length() > 1) {
+            value = trimmed.substring(trimmed.indexOf('-')+1).trim();
+        } else if(trimmed.contains(":") && !trimmed.endsWith(":")) {
+            value = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+        } else {
+            throw new IllegalStateException(
+                "Missing scalar on line " + (this.line.number() + 1) + " . "
+                + "The line was expected to be either part of a "
+                + "mapping (key: value) or part of a sequence (- value)."
+            );
+        }
+        return value;
     }
+
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPointedScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPointedScalar.java
@@ -60,8 +60,8 @@ final class ReadPointedScalar implements YamlNode {
             result = 0;
         } else if (other == null) {
             result = 1;
-        } else if (other instanceof Scalar) {
-            result = this.value().compareTo(((Scalar) other).value());
+        } else if (other instanceof BuiltPlainScalar) {
+            result = this.value().compareTo(((BuiltPlainScalar) other).value());
         } else if (other instanceof ReadPipeScalar) {
             result = this.value().compareTo(((ReadPipeScalar) other).value());
         } else if (other instanceof ReadPointedScalar) {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -145,9 +145,7 @@ final class ReadYamlMapping extends ComparableYamlMapping {
                         break;
                     }
                     if(trimmed.startsWith(":")) {
-                        value = trimmed.substring(
-                            trimmed.indexOf(":") + 1
-                        ).trim();
+                        value = new ReadPlainScalarValue(line).value();
                         break;
                     }
                 }
@@ -165,7 +163,7 @@ final class ReadYamlMapping extends ComparableYamlMapping {
                 continue;
             }
             if(trimmed.startsWith(key + ":")) {
-                value = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+                value = new ReadPlainScalarValue(line).value();
             }
         }
         return value;

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -242,7 +242,7 @@ final class ReadYamlMapping extends ComparableYamlMapping {
                     ).trim();
                     if(!keyPart.isEmpty()) {
                         keys.add(
-                            new Scalar(keyPart)
+                            new BuiltPlainScalar(keyPart)
                         );
                     }
                 }
@@ -259,7 +259,7 @@ final class ReadYamlMapping extends ComparableYamlMapping {
             if(value == null) {
                 final String val = this.string(key);
                 if(val != null) {
-                    value = new Scalar(val);
+                    value = new BuiltPlainScalar(val);
 
                 }
             }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -224,26 +224,12 @@ final class ReadYamlMapping extends ComparableYamlMapping {
         final Set<YamlNode> keys = new TreeSet<>();
         for (final YamlLine line : this.lines) {
             final String trimmed = line.trimmed();
-            if(":".equals(trimmed)) {
+            if(trimmed.startsWith(":")) {
                 continue;
             } else if ("?".equals(trimmed)) {
                 keys.add(this.lines.nested(line.number()).toYamlNode(line));
             } else {
-                final String[] parts = trimmed.split(":");
-                if(parts.length < 2 && !trimmed.endsWith(":")) {
-                    throw new IllegalStateException(
-                        "Expected ':' on line " + line.number()
-                    );
-                } else {
-                    final String keyPart = trimmed.substring(
-                        0, trimmed.indexOf(":")
-                    ).trim();
-                    if(!keyPart.isEmpty()) {
-                        keys.add(
-                            new BuiltPlainScalar(keyPart)
-                        );
-                    }
-                }
+                keys.add(new ReadPlainScalarKey(line));
             }
         }
         return keys;

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -66,12 +66,7 @@ final class ReadYamlSequence extends ComparableYamlSequence {
             if("-".equals(line.trimmed())) {
                 kids.add(this.lines.nested(line.number()).toYamlNode(line));
             } else {
-                final String trimmed = line.trimmed();
-                kids.add(
-                    new BuiltPlainScalar(
-                        trimmed.substring(trimmed.indexOf('-')+1).trim()
-                    )
-                );
+                kids.add(new ReadPlainScalarValue(line));
             }
         }
         return kids;

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -68,7 +68,9 @@ final class ReadYamlSequence extends ComparableYamlSequence {
             } else {
                 final String trimmed = line.trimmed();
                 kids.add(
-                    new Scalar(trimmed.substring(trimmed.indexOf('-')+1).trim())
+                    new BuiltPlainScalar(
+                        trimmed.substring(trimmed.indexOf('-')+1).trim()
+                    )
                 );
             }
         }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -54,7 +54,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlMapping yamlMapping(final String key) {
-        return this.yamlMapping(new Scalar(key));
+        return this.yamlMapping(new BuiltPlainScalar(key));
     }
 
     @Override
@@ -71,7 +71,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlSequence yamlSequence(final String key) {
-        return this.yamlSequence(new Scalar(key));
+        return this.yamlSequence(new BuiltPlainScalar(key));
     }
 
     @Override
@@ -88,7 +88,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public String string(final String key) {
-        return this.string(new Scalar(key));
+        return this.string(new BuiltPlainScalar(key));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
@@ -62,17 +62,17 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
 
     @Override
     public YamlMappingBuilder add(final String key, final String value) {
-        return this.add(new Scalar(key), new Scalar(value));
+        return this.add(new BuiltPlainScalar(key), new BuiltPlainScalar(value));
     }
 
     @Override
     public YamlMappingBuilder add(final YamlNode key, final String value) {
-        return this.add(key, new Scalar(value));
+        return this.add(key, new BuiltPlainScalar(value));
     }
 
     @Override
     public YamlMappingBuilder add(final String key, final YamlNode value) {
-        return this.add(new Scalar(key), value);
+        return this.add(new BuiltPlainScalar(key), value);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -60,7 +60,7 @@ final class RtYamlSequenceBuilder implements YamlSequenceBuilder {
 
     @Override
     public YamlSequenceBuilder add(final String value) {
-        return this.add(new Scalar(value));
+        return this.add(new BuiltPlainScalar(value));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/Scalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Scalar.java
@@ -27,6 +27,9 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.util.Collection;
+import java.util.LinkedList;
+
 /**
  * Yaml Scalar.
  * @author Mihai Andronache (amihaiemil@gmail.com)
@@ -34,7 +37,7 @@ package com.amihaiemil.eoyaml;
  * @since 3.1.3
  */
 public interface Scalar extends YamlNode {
-    
+
     /**
      * Value of this scalar. The value returned by this
      * method should be un-escaped. e.g. if the scalar is
@@ -43,4 +46,28 @@ public interface Scalar extends YamlNode {
      * @return String value.
      */
     String value();
+
+    /**
+     * A scalar has no values.
+     * @return Empty collection.
+     */
+    default Collection<YamlNode> values() {
+        return new LinkedList<>();
+    }
+
+    /**
+     * Indent this scalar. This method is supposed to be default and applicable
+     * to any kind of scalar.
+     * @param indentation Number of preceding spaces of each line.
+     * @return Indented Scalar.
+     */
+    default String indent(final int indentation) {
+        int spaces = indentation;
+        StringBuilder printed = new StringBuilder();
+        while (spaces > 0) {
+            printed.append(" ");
+            spaces--;
+        }
+        return printed.append(this.value()).toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Scalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Scalar.java
@@ -27,112 +27,20 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
-import java.util.LinkedList;
-
 /**
- * YAML scalar.
+ * Yaml Scalar.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.0
- * @see http://yaml.org/spec/1.2/spec.html#scalar//
+ * @since 3.1.3
  */
-final class Scalar implements YamlNode {
-
+public interface Scalar extends YamlNode {
+    
     /**
-     * This scalar's value.
+     * Value of this scalar. The value returned by this
+     * method should be un-escaped. e.g. if the scalar is
+     * escaped, say '#404040', the returned value should be
+     * #404040.
+     * @return String value.
      */
-    private String value;
-
-    /**
-     * Ctor.
-     * @param value Given value for this scalar.
-     */
-    Scalar(final String value) {
-        this.value = value;
-    }
-
-    /**
-     * Value of this scalar.
-     * @return Value of type T.
-     */
-    public String value() {
-        return this.value;
-    }
-
-    @Override
-    public Collection<YamlNode> values() {
-        return new LinkedList<YamlNode>();
-    }
-
-    /**
-     * Equality of two objects.
-     * @param anotherObject Reference to righthand object
-     * @return True if object are equal and False if are not.
-     */
-    @Override
-    public boolean equals(final Object anotherObject) {
-        if (this == anotherObject) {
-            return true;
-        }
-        if (anotherObject == null || getClass() != anotherObject.getClass()) {
-            return false;
-        }
-
-        final Scalar scalar = (Scalar) anotherObject;
-
-        return this.value.equals(scalar.value);
-
-    }
-
-    /**
-     * Hash Code of this scalar.
-     * @return Value of hashCode() of type int.
-     */
-    @Override
-    public int hashCode() {
-        return this.value.hashCode();
-    }
-
-    /**
-     * Compare this Scalar to another node.<br><br>
-     *
-     * A Scalar is always considered less than a Sequence or a Mapping.<br>
-     * If o is Scalar then their String values are compared lexicographically
-     *
-     * @param other The other AbstractNode.
-     * @return
-     *  a value < 0 if this < o <br>
-     *   0 if this == o or <br>
-     *  a value > 0 if this > o
-     */
-    @Override
-    public int compareTo(final YamlNode other) {
-        int result = -1;
-        if (this == other) {
-            result = 0;
-        } else if (other == null) {
-            result = 1;
-        } else if (other instanceof Scalar) {
-            result = this.value.compareTo(((Scalar) other).value);
-        }
-        return result;
-    }
-
-    @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
-    @Override
-    public String indent(final int indentation) {
-        int spaces = indentation;
-        StringBuilder printed = new StringBuilder();
-        while (spaces > 0) {
-            printed.append(" ");
-            spaces--;
-        }
-        return printed.append(this.value).toString();
-    }
-
+    String value();
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Scalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Scalar.java
@@ -44,6 +44,9 @@ public interface Scalar extends YamlNode {
      * escaped, say '#404040', the returned value should be
      * #404040.
      * @return String value.
+     * @throws IllegalStateException In the case of reading YAML,
+     *  this exception is thrown if the Scalar isn't found where it's
+     *  supposed to be.
      */
     String value();
 

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -63,7 +63,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlMapping yamlMapping(final String key) {
-        return this.yamlMapping(new Scalar(key));
+        return this.yamlMapping(new BuiltPlainScalar(key));
     }
 
     @Override
@@ -79,7 +79,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlSequence yamlSequence(final String key) {
-        return this.yamlSequence(new Scalar(key));
+        return this.yamlSequence(new BuiltPlainScalar(key));
     }
 
     @Override
@@ -95,7 +95,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public String string(final String key) {
-        return this.string(new Scalar(key));
+        return this.string(new BuiltPlainScalar(key));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -177,7 +177,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable integer.
      */
     default int integer(final String key) {
-        return this.integer(new Scalar(key));
+        return this.integer(new BuiltPlainScalar(key));
     }
     
     /**
@@ -215,7 +215,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable float.
      */
     default float floatNumber(final String key) {
-        return this.floatNumber(new Scalar(key));
+        return this.floatNumber(new BuiltPlainScalar(key));
     }
     
     /**
@@ -253,7 +253,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable double.
      */
     default double doubleNumber(final String key) {
-        return this.doubleNumber(new Scalar(key));
+        return this.doubleNumber(new BuiltPlainScalar(key));
     }
     
     /**
@@ -291,7 +291,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable long.
      */
     default long longNumber(final String key) {
-        return this.longNumber(new Scalar(key));
+        return this.longNumber(new BuiltPlainScalar(key));
     }
     
     /**
@@ -328,7 +328,7 @@ public interface YamlMapping extends YamlNode {
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDate date(final String key) {
-        return this.date(new Scalar(key));
+        return this.date(new BuiltPlainScalar(key));
     }
     
     /**
@@ -364,7 +364,7 @@ public interface YamlMapping extends YamlNode {
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDateTime dateTime(final String key) {
-        return this.dateTime(new Scalar(key));
+        return this.dateTime(new BuiltPlainScalar(key));
     }
     
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/YamlNode.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlNode.java
@@ -59,7 +59,7 @@ public interface YamlNode extends Comparable<YamlNode> {
 
     /**
      * Print this node with a specified indentation.
-     * @param indentation Number of preciding spaces of each line.
+     * @param indentation Number of preceding spaces of each line.
      * @return String
      */
     String indent(final int indentation);

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltPlainScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltPlainScalarTest.java
@@ -43,7 +43,7 @@ import org.junit.Test;
  * @since 1.0.0
  *
  */
-public final class ScalarTest {
+public final class BuiltPlainScalarTest {
 
     /**
      * Scalar can return its own value.

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltYamlStreamTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltYamlStreamTest.java
@@ -196,7 +196,7 @@ public final class BuiltYamlStreamTest {
     public void greaterThanAScalar() {
         final YamlStream stream = Yaml.createYamlStreamBuilder().build();
         MatcherAssert.assertThat(
-            stream.compareTo(new Scalar("test")),
+            stream.compareTo(new BuiltPlainScalar("test")),
             Matchers.greaterThan(0)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPipeScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPipeScalarTest.java
@@ -37,7 +37,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link ReadPipeScalar}.
+ * Unit tests for {@link ReadLiteralBlockScalar}.
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.2
@@ -53,8 +53,8 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPipeScalar scalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.values(), Matchers.emptyIterable()
         );
@@ -69,8 +69,8 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPipeScalar scalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.value(),
             Matchers.is("First Line.\nSecond Line.\nThird Line.")
@@ -86,8 +86,8 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPipeScalar scalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
@@ -103,8 +103,8 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPipeScalar scalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(scalar.compareTo(seq), Matchers.lessThan(0));
     }
@@ -116,8 +116,8 @@ public final class ReadPipeScalarTest {
     public void comparesToScalar() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("Java", 1));
-        final ReadPipeScalar pipeScalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar pipeScalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
@@ -129,10 +129,10 @@ public final class ReadPipeScalarTest {
     public void comparesToReadPipeScalar() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("Java", 1));
-        final ReadPipeScalar first =
-            new ReadPipeScalar(new AllYamlLines(lines));
-        final ReadPipeScalar second =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar first =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar second =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(first.compareTo(second), Matchers.is(0));
     }
 
@@ -145,8 +145,8 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPipeScalar scalar =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.indent(4),
             Matchers.is("    First Line.\n    Second Line.\n    Third Line.")

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPipeScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPipeScalarTest.java
@@ -118,7 +118,7 @@ public final class ReadPipeScalarTest {
         lines.add(new RtYamlLine("Java", 1));
         final ReadPipeScalar pipeScalar =
             new ReadPipeScalar(new AllYamlLines(lines));
-        final Scalar scalar = new Scalar("Java");
+        final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarKeyTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarKeyTest.java
@@ -33,66 +33,81 @@ import org.junit.Assert;
 import org.junit.Test;
 
 /**
- * Unit tests for {@ling ReadPlainScalarValue}.
+ * Unit tests for {@link ReadPlainScalarKey}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.3
  */
-public final class ReadPlainScalarValueTest {
+public final class ReadPlainScalarKeyTest {
 
     /**
-     * ReadPlainScalarValue can return the scalar's value from a mapping line.
+     * ReadPlainScalarKey can return the key from a YamlLine that
+     * represents a simple key: value mapping.
      */
     @Test
-    public void returnsValueFromMappingLine() {
-        final Scalar scalar = new ReadPlainScalarValue(
+    public void returnsKeyWithScalarValue() {
+        final Scalar scalar = new ReadPlainScalarKey(
             new RtYamlLine("key: value", 0)
         );
-        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("key"));
     }
 
     /**
-     * ReadPlainScalarValue can return the scalar's value from a sequence line.
+     * ReadPlainScalarKey can return the key from a YamlLine that
+     * represents a mapping between a simple key and a YamlNode value.
      */
     @Test
-    public void returnsValueFromSequenceLine() {
-        final Scalar scalar = new ReadPlainScalarValue(
-            new RtYamlLine("- value", 0)
+    public void returnsKeyWithYamlNodeValue() {
+        final Scalar scalar = new ReadPlainScalarKey(
+            new RtYamlLine("key: ", 0)
         );
-        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("key"));
     }
 
     /**
-     * ReadPlainScalarValue should throw an exception if the given line doesn't
-     * contain a scalar.
+     * ReadPlainScalarKey will complain if the given YamlLine contains
+     * the start of a complex key rather than a Scalar key.
      */
     @Test(expected = IllegalStateException.class)
-    public void missingScalarInSequence() {
-        final YamlLine line = new RtYamlLine("-", 0);
-        final Scalar scalar = new ReadPlainScalarValue(line);
+    public void complainsOnStartOfComplexKey() {
+        final YamlLine line = new RtYamlLine("?", 0);
+        final Scalar scalar = new ReadPlainScalarKey(line);
+        scalar.value();
+        Assert.fail("IllegalStateException was expected.");
+
+    }
+
+    /**
+     * ReadPlainScalarKey will complain if the given YamlLine contains
+     * the end of a complex key rather than a Scalar key.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void complainsOnEndOfComplexKey() {
+        final YamlLine line = new RtYamlLine(":", 0);
+        final Scalar scalar = new ReadPlainScalarKey(line);
         scalar.value();
         Assert.fail("IllegalStateException was expected.");
     }
 
     /**
-     * ReadPlainScalarValue should throw an exception if the given line doesn't
-     * contain a scalar.
+     * ReadPlainScalarKey will complain if the given YamlLine is actually
+     * part of a YamlSequence.
      */
     @Test(expected = IllegalStateException.class)
-    public void missingScalarInMapping() {
-        final YamlLine line = new RtYamlLine("key: ", 0);
-        final Scalar scalar = new ReadPlainScalarValue(line);
+    public void complainsOnLineFromSequence() {
+        final YamlLine line = new RtYamlLine("- someValue", 0);
+        final Scalar scalar = new ReadPlainScalarKey(line);
         scalar.value();
         Assert.fail("IllegalStateException was expected.");
     }
 
     /**
-     * ReadPlainScalarValue will complain if the given YamlLine is empty.
+     * ReadPlainScalarKey will complain if the given YamlLine is empty.
      */
     @Test(expected = IllegalStateException.class)
     public void complainsOnEmptyLine() {
         final YamlLine line = new RtYamlLine("", 0);
-        final Scalar scalar = new ReadPlainScalarValue(line);
+        final Scalar scalar = new ReadPlainScalarKey(line);
         scalar.value();
         Assert.fail("IllegalStateException was expected.");
     }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarValueTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarValueTest.java
@@ -27,35 +27,62 @@
  */
 package com.amihaiemil.eoyaml;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Assert;
+import org.junit.Test;
+
 /**
- * YAML Plain scalar to be used when building a YAML, via
- * one of the builders.
+ * Unit tests for {@ling ReadPlainScalarValue}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.0
- * @see http://yaml.org/spec/1.2/spec.html#scalar//
+ * @since 3.1.3
  */
-final class BuiltPlainScalar extends ComparableScalar {
+public final class ReadPlainScalarValueTest {
 
     /**
-     * This scalar's value.
+     * ReadPlainScalarValue can return the scalar's value from a mapping line.
      */
-    private String value;
-
-    /**
-     * Ctor.
-     * @param value Given value for this scalar.
-     */
-    BuiltPlainScalar(final String value) {
-        this.value = value;
+    @Test
+    public void returnsValueFromMappingLine() {
+        final Scalar scalar = new ReadPlainScalarValue(
+            new RtYamlLine("key: value", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
     }
 
     /**
-     * Value of this scalar.
-     * @return Value of type T.
+     * ReadPlainScalarValue can return the scalar's value from a sequence line.
      */
-    @Override
-    public String value() {
-        return this.value;
+    @Test
+    public void returnsValueFromSequenceLine() {
+        final Scalar scalar = new ReadPlainScalarValue(
+            new RtYamlLine("- value", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
+    }
+
+    /**
+     * ReadPlainScalarValue should throw an exception if the given line doesn't
+     * contain a scalar.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void missingScalarInSequence() {
+        final YamlLine line = new RtYamlLine("-", 0);
+        final Scalar scalar = new ReadPlainScalarValue(line);
+        scalar.value();
+        Assert.fail("IllegalStateException was expected.");
+    }
+
+    /**
+     * ReadPlainScalarValue should throw an exception if the given line doesn't
+     * contain a scalar.
+     */
+    @Test(expected = IllegalStateException.class)
+    public void missingScalarInMapping() {
+        final YamlLine line = new RtYamlLine("key: ", 0);
+        final Scalar scalar = new ReadPlainScalarValue(line);
+        scalar.value();
+        Assert.fail("IllegalStateException was expected.");
     }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPointedScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPointedScalarTest.java
@@ -36,7 +36,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link ReadPointedScalar}.
+ * Unit tests for {@link ReadFoldedBlockScalar}.
  * @author Sherif Waly (sherifwaly95@gmail.com)
  * @version $Id$
  * @since 1.0.2
@@ -52,8 +52,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("First Line.", 1));
         lines.add(new RtYamlLine("Second Line.", 2));
         lines.add(new RtYamlLine("Third Line.", 3));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.values(), Matchers.emptyIterable()
         );
@@ -68,8 +68,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("First Line", 1));
         lines.add(new RtYamlLine("Second Line", 2));
         lines.add(new RtYamlLine("Third Line", 3));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
@@ -85,8 +85,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("First Line", 1));
         lines.add(new RtYamlLine("Second Line", 2));
         lines.add(new RtYamlLine("Third Line", 3));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(scalar.compareTo(seq), Matchers.lessThan(0));
     }
@@ -98,8 +98,8 @@ public final class ReadPointedScalarTest {
     public void comparesToScalar() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("Java", 1));
-        final ReadPointedScalar pipeScalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar pipeScalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
@@ -111,10 +111,10 @@ public final class ReadPointedScalarTest {
     public void comparesToReadPipeScalar() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("Java", 1));
-        final ReadPointedScalar first =
-            new ReadPointedScalar(new AllYamlLines(lines));
-        final ReadPipeScalar second =
-            new ReadPipeScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar first =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
+        final ReadLiteralBlockScalar second =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(first.compareTo(second), Matchers.is(0));
     }
 
@@ -125,10 +125,10 @@ public final class ReadPointedScalarTest {
     public void comparesToReadPointedScalar() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("Java", 1));
-        final ReadPointedScalar first =
-            new ReadPointedScalar(new AllYamlLines(lines));
-        final ReadPointedScalar second =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar first =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar second =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(first.compareTo(second), Matchers.is(0));
     }
 
@@ -143,8 +143,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("Mark McGwire's", 1));
         lines.add(new RtYamlLine("year was crippled", 2));
         lines.add(new RtYamlLine("by a knee injury.", 3));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.value(),
             Matchers.is("Mark McGwire's year was crippled by a knee injury.")
@@ -166,8 +166,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("  75 Hits", 5));
         lines.add(new RtYamlLine("", 6));
         lines.add(new RtYamlLine("What a year!", 7));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.value(),
             Matchers.is(
@@ -188,8 +188,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("Mark McGwire's", 1));
         lines.add(new RtYamlLine("year was crippled", 2));
         lines.add(new RtYamlLine("by an injury.", 3));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.indent(4),
             Matchers.is("    Mark McGwire's year was crippled by an injury.")
@@ -208,8 +208,8 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("", 3));
         lines.add(new RtYamlLine("  63 Home Runs", 4));
         lines.add(new RtYamlLine("What a year!", 5));
-        final ReadPointedScalar scalar =
-            new ReadPointedScalar(new AllYamlLines(lines));
+        final ReadFoldedBlockScalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.indent(4),
             Matchers.is(

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPointedScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPointedScalarTest.java
@@ -100,7 +100,7 @@ public final class ReadPointedScalarTest {
         lines.add(new RtYamlLine("Java", 1));
         final ReadPointedScalar pipeScalar =
             new ReadPointedScalar(new AllYamlLines(lines));
-        final Scalar scalar = new Scalar("Java");
+        final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -92,15 +92,15 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("akey"))
+            Matchers.equalTo(new BuiltPlainScalar("akey"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("bkey"))
+            Matchers.equalTo(new BuiltPlainScalar("bkey"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("zkey"))
+            Matchers.equalTo(new BuiltPlainScalar("zkey"))
         );
     }
     
@@ -128,7 +128,7 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("something"))
+            Matchers.equalTo(new BuiltPlainScalar("something"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -150,7 +150,7 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("somethingElse"))
+            Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
         );
     }
     
@@ -184,11 +184,11 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("somethingElse"))
+            Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("something"))
+            Matchers.equalTo(new BuiltPlainScalar("something"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -200,7 +200,7 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new Scalar("simpleValue"))
+            Matchers.equalTo(new BuiltPlainScalar("simpleValue"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -318,10 +318,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode first = map.value(new Scalar("first"));
+        final YamlNode first = map.value(new BuiltPlainScalar("first"));
         MatcherAssert.assertThat(first, Matchers.notNullValue());
         MatcherAssert.assertThat(
-            first, Matchers.equalTo(new Scalar("somethingElse"))
+            first, Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
         );
     }
     
@@ -338,7 +338,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode second = map.value(new Scalar("second"));
+        final YamlNode second = map.value(new BuiltPlainScalar("second"));
         MatcherAssert.assertThat(second, Matchers.notNullValue());
         MatcherAssert.assertThat(
             second, Matchers.instanceOf(YamlSequence.class)
@@ -357,7 +357,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  some: mapping", 2));
         lines.add(new RtYamlLine("third: something", 3));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode second = map.value(new Scalar("second"));
+        final YamlNode second = map.value(new BuiltPlainScalar("second"));
         MatcherAssert.assertThat(second, Matchers.notNullValue());
         MatcherAssert.assertThat(
             second, Matchers.instanceOf(YamlMapping.class)
@@ -375,7 +375,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  some: mapping", 2));
         lines.add(new RtYamlLine("third: something", 3));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode missing = map.value(new Scalar("notthere"));
+        final YamlNode missing = map.value(new BuiltPlainScalar("notthere"));
         MatcherAssert.assertThat(missing, Matchers.nullValue());
     }
     
@@ -395,7 +395,7 @@ public final class ReadYamlMappingTest {
         
         MatcherAssert.assertThat(map.string("notthere"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(
-            new Scalar("notthere")), Matchers.nullValue()
+            new BuiltPlainScalar("notthere")), Matchers.nullValue()
         );
     }
     
@@ -457,7 +457,7 @@ public final class ReadYamlMappingTest {
         
         MatcherAssert.assertThat(map.string("second"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(
-            new Scalar("second")), Matchers.nullValue()
+            new BuiltPlainScalar("second")), Matchers.nullValue()
         );
     }
     
@@ -528,7 +528,7 @@ public final class ReadYamlMappingTest {
             map.yamlSequence("notthere"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new Scalar("notthere")), Matchers.nullValue()
+            new BuiltPlainScalar("notthere")), Matchers.nullValue()
         );
     }
     
@@ -596,7 +596,7 @@ public final class ReadYamlMappingTest {
             map.yamlMapping("first"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new Scalar("first")), Matchers.nullValue()
+            new BuiltPlainScalar("first")), Matchers.nullValue()
         );
     }
     
@@ -618,7 +618,7 @@ public final class ReadYamlMappingTest {
             map.yamlMapping("second"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new Scalar("second")), Matchers.nullValue()
+            new BuiltPlainScalar("second")), Matchers.nullValue()
         );
     }
     
@@ -744,7 +744,7 @@ public final class ReadYamlMappingTest {
             map.yamlMapping("notthere"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new Scalar("notthere")), Matchers.nullValue()
+            new BuiltPlainScalar("notthere")), Matchers.nullValue()
         );
     }
     
@@ -812,7 +812,7 @@ public final class ReadYamlMappingTest {
             map.yamlSequence("first"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new Scalar("first")), Matchers.nullValue()
+            new BuiltPlainScalar("first")), Matchers.nullValue()
         );
     }
     
@@ -834,7 +834,7 @@ public final class ReadYamlMappingTest {
             map.yamlSequence("second"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new Scalar("second")), Matchers.nullValue()
+            new BuiltPlainScalar("second")), Matchers.nullValue()
         );
     }
     

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -182,11 +182,11 @@ public final class RtYamlInputTest {
         final Set<YamlNode> keys = mapping.keys();
         MatcherAssert.assertThat(keys.size(), Matchers.equalTo(2));
         MatcherAssert.assertThat(
-            keys.contains(new Scalar("palette")),
+            keys.contains(new BuiltPlainScalar("palette")),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
-            keys.contains(new Scalar("workspace")),
+            keys.contains(new BuiltPlainScalar("workspace")),
             Matchers.is(Boolean.TRUE)
         );        
         

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
@@ -62,7 +62,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfStringYamlNode() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            "key", new Scalar("value")
+            "key", new BuiltPlainScalar("value")
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -77,7 +77,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfYamlNodeString() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            new Scalar("key"), "value"
+            new BuiltPlainScalar("key"), "value"
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -92,7 +92,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfYamlNodes() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            new Scalar("key"), new Scalar("value")
+            new BuiltPlainScalar("key"), new BuiltPlainScalar("value")
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -107,8 +107,8 @@ public final class RtYamlMappingBuilderTest {
     public void buildsYamlMapping() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         List<YamlNode> devs = new ArrayList<>();
-        devs.add(new Scalar("amihaiemil"));
-        devs.add(new Scalar("salikjan"));
+        devs.add(new BuiltPlainScalar("amihaiemil"));
+        devs.add(new BuiltPlainScalar("salikjan"));
         YamlMapping mapping = mappingBuilder
             .add("architect", "amihaiemil")
             .add("developers", new RtYamlSequence(devs))

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
@@ -46,6 +46,7 @@ import org.mockito.Mockito;
 
 /**
  * Unit tests for {@link RtYamlMapping}.
+ * @checkstyle LineLength (1000 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @ince 1.0.0
@@ -59,9 +60,9 @@ public final class RtYamlMappingTest {
     @Test
     public void fetchesOrderedValues() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key2"), new Scalar("value1"));
-        mappings.put(new Scalar("key3"), new Scalar("value2"));
-        mappings.put(new Scalar("key1"), new Scalar("value3"));
+        mappings.put(new BuiltPlainScalar("key2"), new BuiltPlainScalar("value1"));
+        mappings.put(new BuiltPlainScalar("key3"), new BuiltPlainScalar("value2"));
+        mappings.put(new BuiltPlainScalar("key1"), new BuiltPlainScalar("value3"));
         YamlMapping map = new RtYamlMapping(mappings);
         final Collection<YamlNode> children = map.values();
         MatcherAssert.assertThat(
@@ -70,13 +71,13 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(children.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("value3"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value3"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("value1"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value1"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("value2"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value2"))
         );
     }
 
@@ -86,9 +87,9 @@ public final class RtYamlMappingTest {
     @Test
     public void fetchesOrderedKeys() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
         YamlMapping map = new RtYamlMapping(mappings);
         final Set<YamlNode> keys = map.keys();
         MatcherAssert.assertThat(
@@ -97,13 +98,13 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(keys.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("key1"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key1"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("key2"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key2"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new Scalar("key3"))
+            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key3"))
         );
 
     }
@@ -115,10 +116,10 @@ public final class RtYamlMappingTest {
     public void returnsYamlScalarAsString() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         String value = "value2";
-        Scalar key = new Scalar("key2");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(key, new Scalar(value));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        BuiltPlainScalar key = new BuiltPlainScalar("key2");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(key, new BuiltPlainScalar(value));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
@@ -136,17 +137,17 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingScalar() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        Scalar key = new Scalar("missing");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key4"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        BuiltPlainScalar key = new BuiltPlainScalar("missing");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key4"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.string("missing"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
         
         MatcherAssert.assertThat(
-            map.string(new Scalar("keÿ3")), Matchers.nullValue()
+            map.string(new BuiltPlainScalar("keÿ3")), Matchers.nullValue()
         );
     }
 
@@ -156,8 +157,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsYamlMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
@@ -172,8 +173,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingYamlMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
@@ -190,8 +191,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsYamlSequence() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key3"), Matchers.notNullValue()
@@ -205,8 +206,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingYamlSequence() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key4"), Matchers.nullValue()
@@ -222,8 +223,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingKey() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key4"), Matchers.nullValue()
@@ -247,7 +248,7 @@ public final class RtYamlMappingTest {
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
-        Scalar scalar = new Scalar("java");
+        BuiltPlainScalar scalar = new BuiltPlainScalar("java");
         MatcherAssert.assertThat(
             map.compareTo(scalar),
             Matchers.greaterThan(0)
@@ -275,21 +276,21 @@ public final class RtYamlMappingTest {
     @Test
     public void comparesToMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key3"), new Scalar("value1"));
-        mappings.put(new Scalar("key2"), new Scalar("value2"));
-        mappings.put(new Scalar("key1"), new Scalar("value3"));
+        mappings.put(new BuiltPlainScalar("key3"), new BuiltPlainScalar("value1"));
+        mappings.put(new BuiltPlainScalar("key2"), new BuiltPlainScalar("value2"));
+        mappings.put(new BuiltPlainScalar("key1"), new BuiltPlainScalar("value3"));
         YamlMapping firstmap = new RtYamlMapping(mappings);
         YamlMapping secondmap = new RtYamlMapping(mappings);
-        mappings.put(new Scalar("key4"), new Scalar("value4"));
+        mappings.put(new BuiltPlainScalar("key4"), new BuiltPlainScalar("value4"));
         YamlMapping thirdmap = new RtYamlMapping(mappings);
 
         Map<YamlNode, YamlNode> othermappings = new HashMap<>();
         othermappings.put(
-            new Scalar("architect"),
+            new BuiltPlainScalar("architect"),
             Mockito.mock(YamlSequence.class)
         );
-        othermappings.put(new Scalar("dev"), firstmap);
-        othermappings.put(new Scalar("tester"), secondmap);
+        othermappings.put(new BuiltPlainScalar("dev"), firstmap);
+        othermappings.put(new BuiltPlainScalar("tester"), secondmap);
         YamlMapping fourthmap = new RtYamlMapping(othermappings);
 
         MatcherAssert.assertThat(
@@ -383,11 +384,11 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsScalarValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        Scalar value = new Scalar("value2");
-        Scalar key = new Scalar("key2");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
+        BuiltPlainScalar value = new BuiltPlainScalar("value2");
+        BuiltPlainScalar key = new BuiltPlainScalar("key2");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
@@ -400,10 +401,10 @@ public final class RtYamlMappingTest {
     public void returnsYamlMappingValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlMapping value = Mockito.mock(YamlMapping.class);
-        Scalar key = new Scalar("key2");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
+        BuiltPlainScalar key = new BuiltPlainScalar("key2");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
@@ -416,10 +417,10 @@ public final class RtYamlMappingTest {
     public void returnsYamlSequenceValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
-        Scalar key = new Scalar("key2");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
+        BuiltPlainScalar key = new BuiltPlainScalar("key2");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
@@ -432,14 +433,14 @@ public final class RtYamlMappingTest {
     public void returnsNullOnMissingValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
-        Scalar key = new Scalar("key2");
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlSequence.class));
+        BuiltPlainScalar key = new BuiltPlainScalar("key2");
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
-            map.value(new Scalar("notthere")),
+            map.value(new BuiltPlainScalar("notthere")),
             Matchers.nullValue()
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
@@ -61,7 +61,7 @@ public final class RtYamlSequenceBuilderTest {
     public void addsYamlNode() {
         YamlSequenceBuilder sequenceBuilder = new RtYamlSequenceBuilder();
         YamlSequenceBuilder withAdded =
-            sequenceBuilder.add(new Scalar("value"));
+            sequenceBuilder.add(new BuiltPlainScalar("value"));
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             sequenceBuilder, Matchers.not(Matchers.is(withAdded))
@@ -75,8 +75,8 @@ public final class RtYamlSequenceBuilderTest {
     public void buildsYamlSequence() {
         YamlSequenceBuilder sequenceBuilder = new RtYamlSequenceBuilder();
         List<YamlNode> devs = new LinkedList<>();
-        devs.add(new Scalar("amihaiemil"));
-        devs.add(new Scalar("salikjan"));
+        devs.add(new BuiltPlainScalar("amihaiemil"));
+        devs.add(new BuiltPlainScalar("salikjan"));
         YamlSequence sequence = sequenceBuilder
             .add("amihaiemil")
             .add(new RtYamlSequence(devs))

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
@@ -88,10 +88,10 @@ public final class RtYamlSequenceTest {
     @Test
     public void sequenceKeepsOrder() {
         List<YamlNode> nodes = new LinkedList<>();
-        Scalar first = new Scalar("test");
-        Scalar sec = new Scalar("mihai");
-        Scalar third = new Scalar("amber");
-        Scalar fourth = new Scalar("5433");
+        BuiltPlainScalar first = new BuiltPlainScalar("test");
+        BuiltPlainScalar sec = new BuiltPlainScalar("mihai");
+        BuiltPlainScalar third = new BuiltPlainScalar("amber");
+        BuiltPlainScalar fourth = new BuiltPlainScalar("5433");
         nodes.add(first);
         nodes.add(sec);
         nodes.add(third);
@@ -99,16 +99,16 @@ public final class RtYamlSequenceTest {
         RtYamlSequence seq = new RtYamlSequence(nodes);
         Iterator<YamlNode> ordered = seq.values().iterator();
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(first)
+            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(first)
         );
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(sec)
+            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(sec)
         );
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(third)
+            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(third)
         );
         MatcherAssert.assertThat(
-            (Scalar) ordered.next(), Matchers.equalTo(fourth)
+            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(fourth)
         );
     }
 
@@ -118,9 +118,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlScalarAsString() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new Scalar("test"));
-        nodes.add(new Scalar("amber"));
-        nodes.add(new Scalar("mihai"));
+        nodes.add(new BuiltPlainScalar("test"));
+        nodes.add(new BuiltPlainScalar("amber"));
+        nodes.add(new BuiltPlainScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
             seq.string(1), Matchers.equalTo("amber")
@@ -136,9 +136,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlMapping() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new Scalar("test"));
+        nodes.add(new BuiltPlainScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
-        nodes.add(new Scalar("mihai"));
+        nodes.add(new BuiltPlainScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
             seq.yamlMapping(1), Matchers.notNullValue()
@@ -151,7 +151,7 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlSequence() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new Scalar("test"));
+        nodes.add(new BuiltPlainScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
         nodes.add(Mockito.mock(YamlSequence.class));
         YamlSequence seq = new RtYamlSequence(nodes);
@@ -169,7 +169,7 @@ public final class RtYamlSequenceTest {
     @Test
     public void comparesToScalar() {
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
-        Scalar scalar = new Scalar("java");
+        BuiltPlainScalar scalar = new BuiltPlainScalar("java");
         MatcherAssert.assertThat(
             seq.compareTo(scalar),
             Matchers.greaterThan(0)
@@ -195,10 +195,10 @@ public final class RtYamlSequenceTest {
     @Test
     public void comparesToSequence() {
         List<YamlNode> nodes = new LinkedList<>();
-        Scalar first = new Scalar("test");
-        Scalar sec = new Scalar("mihai");
-        Scalar third = new Scalar("amber");
-        Scalar fourth = new Scalar("5433");
+        BuiltPlainScalar first = new BuiltPlainScalar("test");
+        BuiltPlainScalar sec = new BuiltPlainScalar("mihai");
+        BuiltPlainScalar third = new BuiltPlainScalar("amber");
+        BuiltPlainScalar fourth = new BuiltPlainScalar("5433");
         nodes.add(first);
         nodes.add(sec);
         nodes.add(third);
@@ -210,7 +210,7 @@ public final class RtYamlSequenceTest {
         RtYamlSequence another = new RtYamlSequence(nodes);
 
         nodes.remove(0);
-        nodes.add(0, new Scalar("yaml"));
+        nodes.add(0, new BuiltPlainScalar("yaml"));
         RtYamlSequence sameSize = new RtYamlSequence(nodes);
 
         MatcherAssert.assertThat(seq.compareTo(seq), Matchers.equalTo(0));
@@ -283,9 +283,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsSize(){
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new Scalar("test"));
+        nodes.add(new BuiltPlainScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
-        nodes.add(new Scalar("mihai"));
+        nodes.add(new BuiltPlainScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(seq.size(), Matchers.is(3));
     }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlStreamBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlStreamBuilderTest.java
@@ -79,7 +79,7 @@ public final class RtYamlStreamBuilderTest {
     public void addsScalar() {
         YamlStreamBuilder streamBuilder = new RtYamlStreamBuilder();
         YamlStreamBuilder withAdded = streamBuilder.add(
-            new Scalar("test")            
+            new BuiltPlainScalar("test")            
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(

--- a/src/test/java/com/amihaiemil/eoyaml/ScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ScalarTest.java
@@ -37,7 +37,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link Scalar}.
+ * Unit tests for {@link BuiltPlainScalar}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -51,7 +51,7 @@ public final class ScalarTest {
     @Test
     public void returnsValue() {
         final String val = "test scalar value";
-        final Scalar scl = new Scalar(val);
+        final BuiltPlainScalar scl = new BuiltPlainScalar(val);
         MatcherAssert.assertThat(scl.value(), Matchers.equalTo(val));
     }
 
@@ -61,7 +61,7 @@ public final class ScalarTest {
     @Test
     public void hasNoValues() {
         final String val = "test scalar value";
-        final Scalar scl = new Scalar(val);
+        final BuiltPlainScalar scl = new BuiltPlainScalar(val);
         MatcherAssert.assertThat(
             scl.values(), Matchers.emptyIterable()
         );
@@ -74,8 +74,8 @@ public final class ScalarTest {
     @Test
     public void equalsAndHashCode() {
         final String val = "test scalar value";
-        final Scalar firstScalar = new Scalar(val);
-        final Scalar secondScalar = new Scalar(val);
+        final BuiltPlainScalar firstScalar = new BuiltPlainScalar(val);
+        final BuiltPlainScalar secondScalar = new BuiltPlainScalar(val);
 
         MatcherAssert.assertThat(firstScalar, Matchers.equalTo(secondScalar));
         MatcherAssert.assertThat(secondScalar, Matchers.equalTo(firstScalar));
@@ -94,10 +94,10 @@ public final class ScalarTest {
      */
     @Test
     public void comparesToScalar() {
-        Scalar first = new Scalar("java");
-        Scalar second = new Scalar("java");
-        Scalar digits = new Scalar("123");
-        Scalar otherDigits = new Scalar("124");
+        BuiltPlainScalar first = new BuiltPlainScalar("java");
+        BuiltPlainScalar second = new BuiltPlainScalar("java");
+        BuiltPlainScalar digits = new BuiltPlainScalar("123");
+        BuiltPlainScalar otherDigits = new BuiltPlainScalar("124");
         MatcherAssert.assertThat(first.compareTo(first), Matchers.equalTo(0));
         MatcherAssert.assertThat(first.compareTo(second), Matchers.equalTo(0));
         MatcherAssert.assertThat(
@@ -116,7 +116,7 @@ public final class ScalarTest {
      */
     @Test
     public void comparesToMapping() {
-        Scalar first = new Scalar("java");
+        BuiltPlainScalar first = new BuiltPlainScalar("java");
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
@@ -128,7 +128,7 @@ public final class ScalarTest {
      */
     @Test
     public void comparesToSequence() {
-        Scalar first = new Scalar("java");
+        BuiltPlainScalar first = new BuiltPlainScalar("java");
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(first.compareTo(seq), Matchers.lessThan(0));
     }

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -37,6 +37,7 @@ import org.mockito.Mockito;
 
 /**
  * Unit tests for {@link StrictYamlMapping}.
+ * @checkstyle LineLength (1000 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -49,9 +50,9 @@ public final class StrictYamlMappingTest {
     @Test
     public void fetchesValues() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key2"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
         YamlMapping map = new StrictYamlMapping(new RtYamlMapping(mappings));
         MatcherAssert.assertThat(
             map.values(), Matchers.not(Matchers.emptyIterable())
@@ -65,9 +66,9 @@ public final class StrictYamlMappingTest {
     @Test
     public void fetchesKeys() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new Scalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key2"), Mockito.mock(YamlNode.class));
-        mappings.put(new Scalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
         YamlMapping map = new StrictYamlMapping(new RtYamlMapping(mappings));
         MatcherAssert.assertThat(
             map.keys(), Matchers.not(Matchers.emptyIterable())
@@ -117,7 +118,7 @@ public final class StrictYamlMappingTest {
      */
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullValue() {
-        Scalar key = new Scalar("key");
+        BuiltPlainScalar key = new BuiltPlainScalar("key");
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         Mockito.when(origin.value(key)).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
@@ -131,7 +132,7 @@ public final class StrictYamlMappingTest {
     public void returnsMapping() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlMapping found = Mockito.mock(YamlMapping.class);
-        YamlNode key = new Scalar("key");
+        YamlNode key = new BuiltPlainScalar("key");
         Mockito.when(origin.yamlMapping(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
@@ -146,7 +147,7 @@ public final class StrictYamlMappingTest {
     public void returnsSequence() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlSequence found = Mockito.mock(YamlSequence.class);
-        YamlNode key = new Scalar("key");
+        YamlNode key = new BuiltPlainScalar("key");
         Mockito.when(origin.yamlSequence(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
@@ -160,7 +161,7 @@ public final class StrictYamlMappingTest {
     @Test
     public void returnsString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        YamlNode key = new Scalar("key");
+        YamlNode key = new BuiltPlainScalar("key");
         Mockito.when(origin.string(key)).thenReturn("found");
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
@@ -174,8 +175,8 @@ public final class StrictYamlMappingTest {
     @Test
     public void returnsValue() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        YamlNode key = new Scalar("key");
-        YamlNode value = new Scalar("value");
+        YamlNode key = new BuiltPlainScalar("key");
+        YamlNode value = new BuiltPlainScalar("value");
         Mockito.when(origin.value(key)).thenReturn(value);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
@@ -48,9 +48,9 @@ public final class StrictYamlSequenceTest {
     @Test
     public void fetchesValues() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new Scalar("key1"));
-        elements.add(new Scalar("key2"));
-        elements.add(new Scalar("key3"));
+        elements.add(new BuiltPlainScalar("key1"));
+        elements.add(new BuiltPlainScalar("key2"));
+        elements.add(new BuiltPlainScalar("key3"));
         YamlSequence sequence = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );
@@ -67,9 +67,9 @@ public final class StrictYamlSequenceTest {
     @Test
     public void strictSequenceIsIterable() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new Scalar("key1"));
-        elements.add(new Scalar("key2"));
-        elements.add(new Scalar("key3"));
+        elements.add(new BuiltPlainScalar("key1"));
+        elements.add(new BuiltPlainScalar("key2"));
+        elements.add(new BuiltPlainScalar("key3"));
         YamlSequence seq = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );
@@ -119,8 +119,8 @@ public final class StrictYamlSequenceTest {
     @Test
     public void returnsSize() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new Scalar("key1"));
-        elements.add(new Scalar("key2"));
+        elements.add(new BuiltPlainScalar("key1"));
+        elements.add(new BuiltPlainScalar("key2"));
         YamlSequence sequence = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );


### PR DESCRIPTION
fixes #200 

- turned Scalar into an interface.
- BuiltPlainScalar for building YAML scalars
- ReadPlainScalarValue for reading Scalar values from a mapping or a sequence
- ReadPlainScalarKey for reading a plain Scalar key from a mapping.
- ReadFoldedBlockScalar and ReadLiteralBlockScalar