### PR TITLE
Validate the Indentation of a Read Stream

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -27,7 +27,9 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * YamlLines default implementation. "All" refers to the fact that
@@ -68,6 +70,31 @@ final class AllYamlLines implements YamlLines {
     @Override
     public Collection<YamlLine> lines() {
         return this.lines;
+    }
+
+    /**
+     * Lines which are nested after the given YamlLine (lines which are
+     * <br> indented by 2 or more spaces beneath it).
+     * @param after Number of a YamlLine
+     * @return YamlLines
+     */
+    @Override
+    public AllYamlLines nested(final int after) {
+        final List<YamlLine> nestedLines = new ArrayList<YamlLine>();
+        YamlLine start = null;
+        for(final YamlLine line : this.lines()) {
+            if(line.number() == after) {
+                start = line;
+            }
+            if(line.number() > after) {
+                if(line.indentation() > start.indentation()) {
+                    nestedLines.add(line);
+                } else {
+                    break;
+                }
+            }
+        }
+        return new AllYamlLines(nestedLines);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/CachedYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/CachedYamlLine.java
@@ -92,9 +92,9 @@ final class CachedYamlLine implements YamlLine {
     }
 
     @Override
-    public boolean hasNestedNode() {
+    public boolean requireNestedIndentation() {
         if (this.hasNestedNode == null) {
-            this.hasNestedNode = this.line.hasNestedNode();
+            this.hasNestedNode = this.line.requireNestedIndentation();
         }
         return this.hasNestedNode;
     }

--- a/src/main/java/com/amihaiemil/eoyaml/EvenlyIndentedLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/EvenlyIndentedLine.java
@@ -86,7 +86,7 @@ final class EvenlyIndentedLine implements YamlLine {
     }
 
     @Override
-    public boolean hasNestedNode() {
-        return this.line.hasNestedNode();
+    public boolean requireNestedIndentation() {
+        return this.line.requireNestedIndentation();
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/NoCommentsYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/NoCommentsYamlLine.java
@@ -93,8 +93,8 @@ final class NoCommentsYamlLine implements YamlLine {
     }
 
     @Override
-    public boolean hasNestedNode() {
-        return new RtYamlLine(this.trimmed(), 0).hasNestedNode();
+    public boolean requireNestedIndentation() {
+        return new RtYamlLine(this.trimmed(), 0).requireNestedIndentation();
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/NoDirectivesOrMarkers.java
+++ b/src/main/java/com/amihaiemil/eoyaml/NoDirectivesOrMarkers.java
@@ -89,6 +89,11 @@ final class NoDirectivesOrMarkers implements YamlLines {
     }
 
     @Override
+    public AllYamlLines nested(final int after) {
+        return this.yamlLines.nested(after);
+    }
+
+    @Override
     public YamlNode toYamlNode(final YamlLine prev) {
         return this.yamlLines.toYamlNode(prev);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
@@ -54,7 +54,9 @@ final class ReadYamlStream extends ComparableYamlStream {
      * @param lines All YAML lines as they are read from the input.
      */
     ReadYamlStream(final AllYamlLines lines) {
-        this.lines = new StartMarkers(lines);
+        this.lines = new WellIndented(
+            new StartMarkers(lines)
+        );
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
@@ -99,14 +99,18 @@ final class RtYamlLine implements YamlLine {
     @Override
     public boolean requireNestedIndentation() {
         final boolean result;
-        final String specialCharacters = ":>|-?";
 
-        final CharSequence prevLineLastChar =
-            this.trimmed().substring(this.trimmed().length()-1);
-        if(specialCharacters.contains(prevLineLastChar)) {
-            result = true;
-        } else {
+        if("---".equals(this.trimmed())) {
             result = false;
+        } else {
+            final String specialCharacters = ":>|-?";
+            final CharSequence prevLineLastChar =
+                this.trimmed().substring(this.trimmed().length() - 1);
+            if (specialCharacters.contains(prevLineLastChar)) {
+                result = true;
+            } else {
+                result = false;
+            }
         }
         return result;
     }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
@@ -97,10 +97,10 @@ final class RtYamlLine implements YamlLine {
     }
 
     @Override
-    public boolean hasNestedNode() {
+    public boolean requireNestedIndentation() {
         final boolean result;
         final String specialCharacters = ":>|-?";
-        
+
         final CharSequence prevLineLastChar =
             this.trimmed().substring(this.trimmed().length()-1);
         if(specialCharacters.contains(prevLineLastChar)) {

--- a/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
+++ b/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
@@ -85,6 +85,11 @@ final class SameIndentationLevel implements YamlLines {
     }
 
     @Override
+    public AllYamlLines nested(final int after) {
+        return this.yamlLines.nested(after);
+    }
+    
+    @Override
     public YamlNode toYamlNode(final YamlLine prev) {
         return this.yamlLines.toYamlNode(prev);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -40,18 +40,18 @@ import java.util.List;
  * to do it at YamlLines level, as a decorator, because
  * in some cases, we need to eliminate some of them first (markers,
  * directives etc). <br><br>
- * 
+ *
  * This class can be used as follows:
- * 
+ *
  * <pre>
- * 
+ *
  * YamlLines wellIndented = new SameIndentationLevel(
  *     new WellIndented(lines)
  * );//Iterate over the lines which are at the same indentation level
  * </pre>
  * or
  * <pre>
- * 
+ *
  * YamlLines wellIndented = new SameIndentationLevel(
  *     new WellIndented(
  *         new NoDirectivesOrMarkers(
@@ -60,7 +60,7 @@ import java.util.List;
  *     )
  * );//Iterate over the lines which are at the same indentation level
  * </pre>
- * 
+ *
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.2
@@ -80,7 +80,7 @@ final class WellIndented implements YamlLines {
     WellIndented(final YamlLines yamlLines) {
         this.yamlLines = yamlLines;
     }
-    
+
     /**
      * Returns an iterator over these Yaml lines.
      * It will verify that each line is properly indented in relation
@@ -100,18 +100,19 @@ final class WellIndented implements YamlLines {
                 YamlLine line = iterator.next();
                 int prevIndent = previous.indentation();
                 int lineIndent = line.indentation();
-                if(previous.hasNestedNode()) {
+                if(previous.requireNestedIndentation()) {
                     if(lineIndent != prevIndent+2) {
                         throw new IllegalStateException(
-                            "Indentation of line " + line.number()
-                             + " is not ok. It should be greater than the"
-                             + " previous line's by 2"
+                            "Indentation of line " + (line.number() + 1)
+                             + " is not ok. It should be greater than the one"
+                             + " of line " + (previous.number() + 1)
+                             + " by 2 spaces."
                         );
                     }
                 } else {
                     if(lineIndent > prevIndent) {
                         throw new IllegalStateException(
-                            "Indentation of line " + line.number() + " is "
+                            "Indentation of line " + (line.number() +1) + " is "
                             + "greater than the previous one's. "
                             + "It should be less or equal."
                         );
@@ -123,7 +124,7 @@ final class WellIndented implements YamlLines {
         }
         return wellIndented.iterator();
     }
-    
+
     @Override
     public Collection<YamlLine> lines() {
         return this.yamlLines.lines();

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -86,6 +86,7 @@ final class WellIndented implements YamlLines {
      * It will verify that each line is properly indented in relation
      * to the previous one and will complain if the indentation is not
      * correct.
+     * @checkstyle LineLength (50 lines)
      * @return Iterator over these yaml lines.
      */
     @Override
@@ -110,10 +111,11 @@ final class WellIndented implements YamlLines {
                         );
                     }
                 } else {
-                    if(lineIndent > prevIndent) {
+                    if(!"---".equals(previous.trimmed()) && lineIndent > prevIndent) {
                         throw new IllegalStateException(
                             "Indentation of line " + (line.number() +1) + " is "
-                            + "greater than the previous one's. "
+                            + "greater than the one of line "
+                            + (previous.number() + 1) + ". "
                             + "It should be less or equal."
                         );
                     }
@@ -128,6 +130,11 @@ final class WellIndented implements YamlLines {
     @Override
     public Collection<YamlLine> lines() {
         return this.yamlLines.lines();
+    }
+
+    @Override
+    public AllYamlLines nested(final int after) {
+        return this.yamlLines.nested(after);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/YamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLine.java
@@ -56,10 +56,11 @@ interface YamlLine extends Comparable<YamlLine> {
     int indentation();
 
     /**
-     * Does this line precede a nested node?
+     * Do the following line(s) require a deeper indentation than this line's?
      * @return True or false
      */
-    boolean hasNestedNode();
+    boolean requireNestedIndentation();
+
     /**
      * YamlLine null object.
      */
@@ -86,7 +87,7 @@ interface YamlLine extends Comparable<YamlLine> {
         }
 
         @Override
-        public boolean hasNestedNode() {
+        public boolean requireNestedIndentation() {
             return false;
         }
 

--- a/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
@@ -27,10 +27,8 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
-import java.util.List;
 
 /**
  * Iterable yaml lines.
@@ -56,7 +54,7 @@ interface YamlLines extends Iterable<YamlLine> {
      *  possibilities.
      */
     YamlNode toYamlNode(final YamlLine prev);
-    
+
     /**
      * Default iterator which doesn't skip any line,
      * iterates over all of them.
@@ -65,30 +63,13 @@ interface YamlLines extends Iterable<YamlLine> {
     default Iterator<YamlLine> iterator() {
         return this.lines().iterator();
     }
-    
+
     /**
-     * Lines which are nested after the given YamlLine (lines which are
-     * <br> indented by 2 or more spaces beneath it).
+     * Lines which are nested after the given YamlLine.
      * @param after Number of a YamlLine
      * @return YamlLines
      */
-    default AllYamlLines nested(final int after) {
-        final List<YamlLine> nestedLines = new ArrayList<YamlLine>();
-        YamlLine start = null;
-        for(final YamlLine line : this.lines()) {
-            if(line.number() == after) {
-                start = line;
-            }
-            if(line.number() > after) {
-                if(line.indentation() > start.indentation()) {
-                    nestedLines.add(line);
-                } else {
-                    break;
-                }
-            }
-        }
-        return new AllYamlLines(nestedLines);
-    }
+    AllYamlLines nested(final int after);
 
     /**
      * Get a certain YamlLine.

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlLineTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlLineTest.java
@@ -49,24 +49,25 @@ public final class RtYamlLineTest {
     }
 
     /**
-     * RtYamlLine knows if it has a nested YamlNode after it.
+     * RtYamlLine knows if the following line(s) require a deeped indentation
+     * or not.
      */
     @Test
-    public void precedesYamlNode() {
+    public void requiresNestedIndentation() {
         MatcherAssert.assertThat(
-            new RtYamlLine("this:", 12).hasNestedNode(),
+            new RtYamlLine("this:", 12).requireNestedIndentation(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new RtYamlLine("this: |> ", 12).hasNestedNode(),
+            new RtYamlLine("this: |> ", 12).requireNestedIndentation(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new RtYamlLine("this: |- ", 12).hasNestedNode(),
+            new RtYamlLine("this: |- ", 12).requireNestedIndentation(),
             Matchers.is(true)
         );
         MatcherAssert.assertThat(
-            new RtYamlLine("this: value", 12).hasNestedNode(),
+            new RtYamlLine("this: value", 12).requireNestedIndentation(),
             Matchers.is(false)
         );
     }


### PR DESCRIPTION
pr for #210 

* renamed ``YamlLine.hasNestedNode()`` -> ``YamlLine.requireNestedIndentation()``
* validated the indentation of the Start Markers when reading a Yaml Stream (the values are validated in cascade when each of them are being read)
* made ``YamlLines.nested(...)`` abstract as now it can have multiple different implementations and thus it must be implemented or delegated by each YamlLines implementations.