### PR TITLE
Renamed BuildPlainScalar to PlainStringScalar

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
@@ -28,14 +28,18 @@
 package com.amihaiemil.eoyaml;
 
 /**
- * YAML Plain scalar to be used when building a YAML, via
- * one of the builders.
+ * YAML Plain scalar from String. Use this class when dealing with
+ * built YAML or in the unit tests.
+ *
+ * DO NOT use it when READING yaml. For reading use
+ * {@link ReadPlainScalarValue}!
+ *
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  * @see http://yaml.org/spec/1.2/spec.html#scalar//
  */
-final class BuiltPlainScalar extends ComparableScalar {
+final class PlainStringScalar extends ComparableScalar {
 
     /**
      * This scalar's value.
@@ -46,7 +50,7 @@ final class BuiltPlainScalar extends ComparableScalar {
      * Ctor.
      * @param value Given value for this scalar.
      */
-    BuiltPlainScalar(final String value) {
+    PlainStringScalar(final String value) {
         this.value = value;
     }
 

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -243,7 +243,7 @@ final class ReadYamlMapping extends ComparableYamlMapping {
             if(value == null) {
                 final String val = this.string(key);
                 if(val != null) {
-                    value = new BuiltPlainScalar(val);
+                    value = new PlainStringScalar(val);
 
                 }
             }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -54,7 +54,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlMapping yamlMapping(final String key) {
-        return this.yamlMapping(new BuiltPlainScalar(key));
+        return this.yamlMapping(new PlainStringScalar(key));
     }
 
     @Override
@@ -71,7 +71,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlSequence yamlSequence(final String key) {
-        return this.yamlSequence(new BuiltPlainScalar(key));
+        return this.yamlSequence(new PlainStringScalar(key));
     }
 
     @Override
@@ -88,7 +88,7 @@ final class RtYamlMapping extends ComparableYamlMapping {
 
     @Override
     public String string(final String key) {
-        return this.string(new BuiltPlainScalar(key));
+        return this.string(new PlainStringScalar(key));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
@@ -62,17 +62,20 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
 
     @Override
     public YamlMappingBuilder add(final String key, final String value) {
-        return this.add(new BuiltPlainScalar(key), new BuiltPlainScalar(value));
+        return this.add(
+            new PlainStringScalar(key),
+            new PlainStringScalar(value)
+        );
     }
 
     @Override
     public YamlMappingBuilder add(final YamlNode key, final String value) {
-        return this.add(key, new BuiltPlainScalar(value));
+        return this.add(key, new PlainStringScalar(value));
     }
 
     @Override
     public YamlMappingBuilder add(final String key, final YamlNode value) {
-        return this.add(new BuiltPlainScalar(key), value);
+        return this.add(new PlainStringScalar(key), value);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -60,7 +60,7 @@ final class RtYamlSequenceBuilder implements YamlSequenceBuilder {
 
     @Override
     public YamlSequenceBuilder add(final String value) {
-        return this.add(new BuiltPlainScalar(value));
+        return this.add(new PlainStringScalar(value));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -63,7 +63,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlMapping yamlMapping(final String key) {
-        return this.yamlMapping(new BuiltPlainScalar(key));
+        return this.yamlMapping(new PlainStringScalar(key));
     }
 
     @Override
@@ -79,7 +79,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public YamlSequence yamlSequence(final String key) {
-        return this.yamlSequence(new BuiltPlainScalar(key));
+        return this.yamlSequence(new PlainStringScalar(key));
     }
 
     @Override
@@ -95,7 +95,7 @@ public final class StrictYamlMapping extends ComparableYamlMapping {
 
     @Override
     public String string(final String key) {
-        return this.string(new BuiltPlainScalar(key));
+        return this.string(new PlainStringScalar(key));
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -178,7 +178,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable integer.
      */
     default int integer(final String key) {
-        return this.integer(new BuiltPlainScalar(key));
+        return this.integer(new PlainStringScalar(key));
     }
 
     /**
@@ -216,7 +216,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable float.
      */
     default float floatNumber(final String key) {
-        return this.floatNumber(new BuiltPlainScalar(key));
+        return this.floatNumber(new PlainStringScalar(key));
     }
 
     /**
@@ -254,7 +254,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable double.
      */
     default double doubleNumber(final String key) {
-        return this.doubleNumber(new BuiltPlainScalar(key));
+        return this.doubleNumber(new PlainStringScalar(key));
     }
 
     /**
@@ -292,7 +292,7 @@ public interface YamlMapping extends YamlNode {
      *  is not a parsable long.
      */
     default long longNumber(final String key) {
-        return this.longNumber(new BuiltPlainScalar(key));
+        return this.longNumber(new PlainStringScalar(key));
     }
 
     /**
@@ -329,7 +329,7 @@ public interface YamlMapping extends YamlNode {
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDate date(final String key) {
-        return this.date(new BuiltPlainScalar(key));
+        return this.date(new PlainStringScalar(key));
     }
 
     /**
@@ -365,7 +365,7 @@ public interface YamlMapping extends YamlNode {
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
     default LocalDateTime dateTime(final String key) {
-        return this.dateTime(new BuiltPlainScalar(key));
+        return this.dateTime(new PlainStringScalar(key));
     }
 
     /**

--- a/src/test/java/com/amihaiemil/eoyaml/AllYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/AllYamlLinesTest.java
@@ -151,17 +151,17 @@ public final class AllYamlLinesTest {
         MatcherAssert.assertThat(values.size(), Matchers.is(3));
         System.out.print(values);
         MatcherAssert.assertThat(
-            values.contains(new BuiltPlainScalar("value1")),
+            values.contains(new PlainStringScalar("value1")),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
             values.contains(
-                new BuiltPlainScalar("value2")
+                new PlainStringScalar("value2")
             ),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
-            values.contains(new BuiltPlainScalar("value3")),
+            values.contains(new PlainStringScalar("value3")),
             Matchers.is(Boolean.TRUE)
         );
     }
@@ -188,17 +188,17 @@ public final class AllYamlLinesTest {
         MatcherAssert.assertThat(values.size(), Matchers.is(3));
         System.out.print(values);
         MatcherAssert.assertThat(
-            values.contains(new BuiltPlainScalar("value1")),
+            values.contains(new PlainStringScalar("value1")),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
             values.contains(
-                new BuiltPlainScalar("value2")
+                new PlainStringScalar("value2")
             ),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
-            values.contains(new BuiltPlainScalar("value3")),
+            values.contains(new PlainStringScalar("value3")),
             Matchers.is(Boolean.TRUE)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltYamlStreamTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltYamlStreamTest.java
@@ -196,7 +196,7 @@ public final class BuiltYamlStreamTest {
     public void greaterThanAScalar() {
         final YamlStream stream = Yaml.createYamlStreamBuilder().build();
         MatcherAssert.assertThat(
-            stream.compareTo(new BuiltPlainScalar("test")),
+            stream.compareTo(new PlainStringScalar("test")),
             Matchers.greaterThan(0)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
@@ -37,13 +37,13 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link BuiltPlainScalar}.
+ * Unit tests for {@link PlainStringScalar}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
  *
  */
-public final class BuiltPlainScalarTest {
+public final class PlainStringScalarTest {
 
     /**
      * Scalar can return its own value.
@@ -51,7 +51,7 @@ public final class BuiltPlainScalarTest {
     @Test
     public void returnsValue() {
         final String val = "test scalar value";
-        final BuiltPlainScalar scl = new BuiltPlainScalar(val);
+        final PlainStringScalar scl = new PlainStringScalar(val);
         MatcherAssert.assertThat(scl.value(), Matchers.equalTo(val));
     }
 
@@ -61,7 +61,7 @@ public final class BuiltPlainScalarTest {
     @Test
     public void hasNoValues() {
         final String val = "test scalar value";
-        final BuiltPlainScalar scl = new BuiltPlainScalar(val);
+        final PlainStringScalar scl = new PlainStringScalar(val);
         MatcherAssert.assertThat(
             scl.values(), Matchers.emptyIterable()
         );
@@ -74,8 +74,8 @@ public final class BuiltPlainScalarTest {
     @Test
     public void equalsAndHashCode() {
         final String val = "test scalar value";
-        final BuiltPlainScalar firstScalar = new BuiltPlainScalar(val);
-        final BuiltPlainScalar secondScalar = new BuiltPlainScalar(val);
+        final PlainStringScalar firstScalar = new PlainStringScalar(val);
+        final PlainStringScalar secondScalar = new PlainStringScalar(val);
 
         MatcherAssert.assertThat(firstScalar, Matchers.equalTo(secondScalar));
         MatcherAssert.assertThat(secondScalar, Matchers.equalTo(firstScalar));
@@ -94,10 +94,10 @@ public final class BuiltPlainScalarTest {
      */
     @Test
     public void comparesToScalar() {
-        BuiltPlainScalar first = new BuiltPlainScalar("java");
-        BuiltPlainScalar second = new BuiltPlainScalar("java");
-        BuiltPlainScalar digits = new BuiltPlainScalar("123");
-        BuiltPlainScalar otherDigits = new BuiltPlainScalar("124");
+        PlainStringScalar first = new PlainStringScalar("java");
+        PlainStringScalar second = new PlainStringScalar("java");
+        PlainStringScalar digits = new PlainStringScalar("123");
+        PlainStringScalar otherDigits = new PlainStringScalar("124");
         MatcherAssert.assertThat(first.compareTo(first), Matchers.equalTo(0));
         MatcherAssert.assertThat(first.compareTo(second), Matchers.equalTo(0));
         MatcherAssert.assertThat(
@@ -116,7 +116,7 @@ public final class BuiltPlainScalarTest {
      */
     @Test
     public void comparesToMapping() {
-        BuiltPlainScalar first = new BuiltPlainScalar("java");
+        PlainStringScalar first = new PlainStringScalar("java");
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
@@ -128,7 +128,7 @@ public final class BuiltPlainScalarTest {
      */
     @Test
     public void comparesToSequence() {
-        BuiltPlainScalar first = new BuiltPlainScalar("java");
+        PlainStringScalar first = new PlainStringScalar("java");
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(first.compareTo(seq), Matchers.lessThan(0));
     }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
@@ -100,7 +100,7 @@ public final class ReadFoldedBlockScalarTest {
         lines.add(new RtYamlLine("Java", 1));
         final ReadFoldedBlockScalar pipeScalar =
             new ReadFoldedBlockScalar(new AllYamlLines(lines));
-        final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
+        final PlainStringScalar scalar = new PlainStringScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
@@ -122,7 +122,7 @@ public final class ReadLiteralBlockScalarTest {
         lines.add(new RtYamlLine("Java", 1));
         final ReadLiteralBlockScalar pipeScalar =
             new ReadLiteralBlockScalar(new AllYamlLines(lines));
-        final BuiltPlainScalar scalar = new BuiltPlainScalar("Java");
+        final PlainStringScalar scalar = new PlainStringScalar("Java");
         MatcherAssert.assertThat(pipeScalar.compareTo(scalar), Matchers.is(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -92,18 +92,18 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("akey"))
+            Matchers.equalTo(new PlainStringScalar("akey"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("bkey"))
+            Matchers.equalTo(new PlainStringScalar("bkey"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("zkey"))
+            Matchers.equalTo(new PlainStringScalar("zkey"))
         );
     }
-    
+
     /**
      * ReadYamlMapping can return its key-ordered children.
      */
@@ -128,7 +128,7 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("something"))
+            Matchers.equalTo(new PlainStringScalar("something"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -150,10 +150,10 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
+            Matchers.equalTo(new PlainStringScalar("somethingElse"))
         );
     }
-    
+
     /**
      * ReadYamlMapping can return its key-ordered children.
      * @checkstyle ExecutableStatementCount (100 lines)
@@ -174,7 +174,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 10));
         lines.add(new RtYamlLine("  - key", 11));
         lines.add(new RtYamlLine(": simpleValue", 12));
-        
+
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
         System.out.print(map);
         final Collection<YamlNode> children = map.values();
@@ -184,11 +184,11 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
+            Matchers.equalTo(new PlainStringScalar("somethingElse"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("something"))
+            Matchers.equalTo(new PlainStringScalar("something"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -200,7 +200,7 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new BuiltPlainScalar("simpleValue"))
+            Matchers.equalTo(new PlainStringScalar("simpleValue"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -211,7 +211,7 @@ public final class ReadYamlMappingTest {
             )
         );
     }
-    
+
     /**
      * ReadYamlMapping can return the YamlMapping mapped to a
      * YamlMapping key.
@@ -318,13 +318,13 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode first = map.value(new BuiltPlainScalar("first"));
+        final YamlNode first = map.value(new PlainStringScalar("first"));
         MatcherAssert.assertThat(first, Matchers.notNullValue());
         MatcherAssert.assertThat(
-            first, Matchers.equalTo(new BuiltPlainScalar("somethingElse"))
+            first, Matchers.equalTo(new PlainStringScalar("somethingElse"))
         );
     }
-    
+
     /**
      * ReadYamlMapping can return the Sequence mapped to a
      * Scalar key.
@@ -338,13 +338,13 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode second = map.value(new BuiltPlainScalar("second"));
+        final YamlNode second = map.value(new PlainStringScalar("second"));
         MatcherAssert.assertThat(second, Matchers.notNullValue());
         MatcherAssert.assertThat(
             second, Matchers.instanceOf(YamlSequence.class)
         );
     }
-    
+
     /**
      * ReadYamlMapping can return the Mapping mapped to a
      * Scalar key.
@@ -357,13 +357,13 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  some: mapping", 2));
         lines.add(new RtYamlLine("third: something", 3));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode second = map.value(new BuiltPlainScalar("second"));
+        final YamlNode second = map.value(new PlainStringScalar("second"));
         MatcherAssert.assertThat(second, Matchers.notNullValue());
         MatcherAssert.assertThat(
             second, Matchers.instanceOf(YamlMapping.class)
         );
     }
-    
+
     /**
      * ReadYamlMapping can return null if value is missing.
      */
@@ -375,10 +375,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  some: mapping", 2));
         lines.add(new RtYamlLine("third: something", 3));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        final YamlNode missing = map.value(new BuiltPlainScalar("notthere"));
+        final YamlNode missing = map.value(new PlainStringScalar("notthere"));
         MatcherAssert.assertThat(missing, Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.string(...) returns null if the queried
      * Scalar is not present.
@@ -392,13 +392,13 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.string("notthere"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(
-            new BuiltPlainScalar("notthere")), Matchers.nullValue()
+            new PlainStringScalar("notthere")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.string(YamlMapping) returns null if the queried
      * Scalar is not present.
@@ -416,10 +416,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.string(YamlSequence) returns null if the queried
      * Scalar is not present.
@@ -437,10 +437,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.string(...) returns null if the queried value
      * is present but it is not actually a Scalar.
@@ -454,13 +454,13 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.string("second"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(
-            new BuiltPlainScalar("second")), Matchers.nullValue()
+            new PlainStringScalar("second")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.string(YamlMapping) returns null if the queried value
      * is present but it is not actually a Scalar.
@@ -485,7 +485,7 @@ public final class ReadYamlMappingTest {
         System.out.println(">>>");
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.string(YamlSequence) returns null if the queried value
      * is present but it is not actually a Scalar.
@@ -506,7 +506,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 6));
         lines.add(new RtYamlLine("second: something", 7));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
     }
 
@@ -523,15 +523,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlSequence("notthere"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new BuiltPlainScalar("notthere")), Matchers.nullValue()
+            new PlainStringScalar("notthere")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(...) returns null if the queried
      * YamlSequence is not present, based on a complex key.
@@ -551,10 +551,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  map: value", 5));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(...) returns null if the queried
      * YamlMapping is not present.
@@ -574,10 +574,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  map: value", 5));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(String) returns null if the queried
      * key has a value that is a Scalar.
@@ -591,15 +591,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlMapping("first"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new BuiltPlainScalar("first")), Matchers.nullValue()
+            new PlainStringScalar("first")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(String) returns null if the queried
      * key has a value that is a YamlSequence.
@@ -613,15 +613,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlMapping("second"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new BuiltPlainScalar("second")), Matchers.nullValue()
+            new PlainStringScalar("second")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(YamlNode) returns null if the queried
      * complex key has a Scalar value.
@@ -640,10 +640,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine(": scalarValue", 4));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(YamlNode) returns null if the queried
      * complex key has a YamlSequence value.
@@ -664,10 +664,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - seq", 6));
         lines.add(new RtYamlLine("second: something", 7));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(YamlNode) returns null if the queried
      * complex key has a Scalar value.
@@ -686,10 +686,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine(": scalarValue", 4));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(YamlNode) returns null if the queried
      * complex key has a YamlSequence value.
@@ -710,10 +710,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 6));
         lines.add(new RtYamlLine("second: something", 7));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * An empty ReadYamlMapping can be printed.
      * @throws Exception if something goes wrong
@@ -725,7 +725,7 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(map.toString(), Matchers.isEmptyString());
     }
-        
+
     /**
      * ReadYamlMapping.yamlMapping(...) returns null if the queried
      * YamlMapping is not present.
@@ -739,15 +739,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlMapping("notthere"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlMapping(
-            new BuiltPlainScalar("notthere")), Matchers.nullValue()
+            new PlainStringScalar("notthere")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlMapping(...) returns null if the queried
      * YamlMapping is not present.
@@ -767,10 +767,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  map: value", 5));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlMapping(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(...) returns null if the queried
      * YamlSequence is not present.
@@ -790,10 +790,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  map: value", 5));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(String) returns null if the queried
      * key has a value that is a Scalar.
@@ -807,15 +807,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  - sequence", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlSequence("first"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new BuiltPlainScalar("first")), Matchers.nullValue()
+            new PlainStringScalar("first")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(String) returns null if the queried
      * key has a value that is a YamlMapping.
@@ -829,15 +829,15 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  key2: notSeq", 3));
         lines.add(new RtYamlLine("third: something", 4));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(
             map.yamlSequence("second"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(map.yamlSequence(
-            new BuiltPlainScalar("second")), Matchers.nullValue()
+            new PlainStringScalar("second")), Matchers.nullValue()
         );
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(YamlNode) returns null if the queried
      * complex key has a Scalar value.
@@ -856,10 +856,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine(": scalarValue", 4));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(YamlNode) returns null if the queried
      * complex key has a YamlMapping value.
@@ -880,10 +880,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  not: seq", 6));
         lines.add(new RtYamlLine("second: something", 7));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(YamlNode) returns null if the queried
      * complex key has a Scalar value.
@@ -902,10 +902,10 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine(": scalarValue", 4));
         lines.add(new RtYamlLine("second: something", 6));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
-    
+
     /**
      * ReadYamlMapping.yamlSequence(YamlNode) returns null if the queried
      * complex key has a YamlMapping value.
@@ -926,7 +926,7 @@ public final class ReadYamlMappingTest {
         lines.add(new RtYamlLine("  not: seq", 6));
         lines.add(new RtYamlLine("second: something", 7));
         final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
-        
+
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -184,11 +184,11 @@ public final class RtYamlInputTest {
         final Set<YamlNode> keys = mapping.keys();
         MatcherAssert.assertThat(keys.size(), Matchers.equalTo(2));
         MatcherAssert.assertThat(
-            keys.contains(new BuiltPlainScalar("palette")),
+            keys.contains(new PlainStringScalar("palette")),
             Matchers.is(Boolean.TRUE)
         );
         MatcherAssert.assertThat(
-            keys.contains(new BuiltPlainScalar("workspace")),
+            keys.contains(new PlainStringScalar("workspace")),
             Matchers.is(Boolean.TRUE)
         );
 

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
@@ -62,7 +62,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfStringYamlNode() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            "key", new BuiltPlainScalar("value")
+            "key", new PlainStringScalar("value")
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -77,7 +77,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfYamlNodeString() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            new BuiltPlainScalar("key"), "value"
+            new PlainStringScalar("key"), "value"
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -92,7 +92,7 @@ public final class RtYamlMappingBuilderTest {
     public void addsPairOfYamlNodes() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         YamlMappingBuilder withAdded = mappingBuilder.add(
-            new BuiltPlainScalar("key"), new BuiltPlainScalar("value")
+            new PlainStringScalar("key"), new PlainStringScalar("value")
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
@@ -107,8 +107,8 @@ public final class RtYamlMappingBuilderTest {
     public void buildsYamlMapping() {
         YamlMappingBuilder mappingBuilder = new RtYamlMappingBuilder();
         List<YamlNode> devs = new ArrayList<>();
-        devs.add(new BuiltPlainScalar("amihaiemil"));
-        devs.add(new BuiltPlainScalar("salikjan"));
+        devs.add(new PlainStringScalar("amihaiemil"));
+        devs.add(new PlainStringScalar("salikjan"));
         YamlMapping mapping = mappingBuilder
             .add("architect", "amihaiemil")
             .add("developers", new RtYamlSequence(devs))

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
@@ -60,9 +60,9 @@ public final class RtYamlMappingTest {
     @Test
     public void fetchesOrderedValues() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key2"), new BuiltPlainScalar("value1"));
-        mappings.put(new BuiltPlainScalar("key3"), new BuiltPlainScalar("value2"));
-        mappings.put(new BuiltPlainScalar("key1"), new BuiltPlainScalar("value3"));
+        mappings.put(new PlainStringScalar("key2"), new PlainStringScalar("value1"));
+        mappings.put(new PlainStringScalar("key3"), new PlainStringScalar("value2"));
+        mappings.put(new PlainStringScalar("key1"), new PlainStringScalar("value3"));
         YamlMapping map = new RtYamlMapping(mappings);
         final Collection<YamlNode> children = map.values();
         MatcherAssert.assertThat(
@@ -71,13 +71,13 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(children.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value3"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("value3"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value1"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("value1"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("value2"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("value2"))
         );
     }
 
@@ -87,9 +87,9 @@ public final class RtYamlMappingTest {
     @Test
     public void fetchesOrderedKeys() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
         YamlMapping map = new RtYamlMapping(mappings);
         final Set<YamlNode> keys = map.keys();
         MatcherAssert.assertThat(
@@ -98,13 +98,13 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(keys.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key1"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("key1"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key2"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("key2"))
         );
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new BuiltPlainScalar("key3"))
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("key3"))
         );
 
     }
@@ -116,10 +116,10 @@ public final class RtYamlMappingTest {
     public void returnsYamlScalarAsString() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         String value = "value2";
-        BuiltPlainScalar key = new BuiltPlainScalar("key2");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(key, new BuiltPlainScalar(value));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        PlainStringScalar key = new PlainStringScalar("key2");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(key, new PlainStringScalar(value));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
@@ -129,7 +129,7 @@ public final class RtYamlMappingTest {
             map.string(key), Matchers.equalTo(value)
         );
     }
-    
+
     /**
      * RtYamlMapping can return null if the queried Scalar is missing or
      * the found value is not actually a Scalar.
@@ -137,17 +137,17 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingScalar() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        BuiltPlainScalar key = new BuiltPlainScalar("missing");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key4"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        PlainStringScalar key = new PlainStringScalar("missing");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key4"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.string("missing"), Matchers.nullValue());
         MatcherAssert.assertThat(map.string(key), Matchers.nullValue());
-        
+
         MatcherAssert.assertThat(
-            map.string(new BuiltPlainScalar("keÿ3")), Matchers.nullValue()
+            map.string(new PlainStringScalar("keÿ3")), Matchers.nullValue()
         );
     }
 
@@ -157,15 +157,15 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsYamlMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
             map.yamlMapping("key1"), Matchers.notNullValue()
         );
     }
-    
+
     /**
      * RtYamlMapping can return null if the queried YamlMapping is missing or
      * if the found value is not actually a YamlMapping.
@@ -173,8 +173,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingYamlMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
@@ -191,14 +191,14 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsYamlSequence() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key3"), Matchers.notNullValue()
         );
     }
-    
+
     /**
      * RtYamlMapping can return null if the queried YamlSequence is missing or
      * if the found value is not actually a YamlSequence.
@@ -206,8 +206,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingYamlSequence() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key4"), Matchers.nullValue()
@@ -223,8 +223,8 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsNullOnMissingKey() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
         MatcherAssert.assertThat(
             map.yamlSequence("key4"), Matchers.nullValue()
@@ -248,7 +248,7 @@ public final class RtYamlMappingTest {
         RtYamlMapping map = new RtYamlMapping(
             new HashMap<YamlNode, YamlNode>()
         );
-        BuiltPlainScalar scalar = new BuiltPlainScalar("java");
+        PlainStringScalar scalar = new PlainStringScalar("java");
         MatcherAssert.assertThat(
             map.compareTo(scalar),
             Matchers.greaterThan(0)
@@ -276,21 +276,21 @@ public final class RtYamlMappingTest {
     @Test
     public void comparesToMapping() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key3"), new BuiltPlainScalar("value1"));
-        mappings.put(new BuiltPlainScalar("key2"), new BuiltPlainScalar("value2"));
-        mappings.put(new BuiltPlainScalar("key1"), new BuiltPlainScalar("value3"));
+        mappings.put(new PlainStringScalar("key3"), new PlainStringScalar("value1"));
+        mappings.put(new PlainStringScalar("key2"), new PlainStringScalar("value2"));
+        mappings.put(new PlainStringScalar("key1"), new PlainStringScalar("value3"));
         YamlMapping firstmap = new RtYamlMapping(mappings);
         YamlMapping secondmap = new RtYamlMapping(mappings);
-        mappings.put(new BuiltPlainScalar("key4"), new BuiltPlainScalar("value4"));
+        mappings.put(new PlainStringScalar("key4"), new PlainStringScalar("value4"));
         YamlMapping thirdmap = new RtYamlMapping(mappings);
 
         Map<YamlNode, YamlNode> othermappings = new HashMap<>();
         othermappings.put(
-            new BuiltPlainScalar("architect"),
+            new PlainStringScalar("architect"),
             Mockito.mock(YamlSequence.class)
         );
-        othermappings.put(new BuiltPlainScalar("dev"), firstmap);
-        othermappings.put(new BuiltPlainScalar("tester"), secondmap);
+        othermappings.put(new PlainStringScalar("dev"), firstmap);
+        othermappings.put(new PlainStringScalar("tester"), secondmap);
         YamlMapping fourthmap = new RtYamlMapping(othermappings);
 
         MatcherAssert.assertThat(
@@ -384,16 +384,16 @@ public final class RtYamlMappingTest {
     @Test
     public void returnsScalarValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        BuiltPlainScalar value = new BuiltPlainScalar("value2");
-        BuiltPlainScalar key = new BuiltPlainScalar("key2");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        PlainStringScalar value = new PlainStringScalar("value2");
+        PlainStringScalar key = new PlainStringScalar("key2");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
     }
-    
+
     /**
      * RtYamlMapping.value(YamlNode) can return a found YamlMapping value.
      */
@@ -401,15 +401,15 @@ public final class RtYamlMappingTest {
     public void returnsYamlMappingValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlMapping value = Mockito.mock(YamlMapping.class);
-        BuiltPlainScalar key = new BuiltPlainScalar("key2");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        PlainStringScalar key = new PlainStringScalar("key2");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
     }
-    
+
     /**
      * RtYamlMapping.value(YamlNode) can return a found YamlSequence value.
      */
@@ -417,15 +417,15 @@ public final class RtYamlMappingTest {
     public void returnsYamlSequenceValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
-        BuiltPlainScalar key = new BuiltPlainScalar("key2");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        PlainStringScalar key = new PlainStringScalar("key2");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(map.value(key), Matchers.equalTo(value));
     }
-    
+
     /**
      * RtYamlMapping.value(YamlNode) can return null if the value is not there.
      */
@@ -433,18 +433,18 @@ public final class RtYamlMappingTest {
     public void returnsNullOnMissingValue() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
-        BuiltPlainScalar key = new BuiltPlainScalar("key2");
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlSequence.class));
+        PlainStringScalar key = new PlainStringScalar("key2");
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(key, value);
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlMapping.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
 
         MatcherAssert.assertThat(
-            map.value(new BuiltPlainScalar("notthere")),
+            map.value(new PlainStringScalar("notthere")),
             Matchers.nullValue()
         );
     }
-    
+
     /**
      * Read a test resource file's contents.
      * @param fileName File to read.

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
@@ -61,7 +61,7 @@ public final class RtYamlSequenceBuilderTest {
     public void addsYamlNode() {
         YamlSequenceBuilder sequenceBuilder = new RtYamlSequenceBuilder();
         YamlSequenceBuilder withAdded =
-            sequenceBuilder.add(new BuiltPlainScalar("value"));
+            sequenceBuilder.add(new PlainStringScalar("value"));
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             sequenceBuilder, Matchers.not(Matchers.is(withAdded))
@@ -75,8 +75,8 @@ public final class RtYamlSequenceBuilderTest {
     public void buildsYamlSequence() {
         YamlSequenceBuilder sequenceBuilder = new RtYamlSequenceBuilder();
         List<YamlNode> devs = new LinkedList<>();
-        devs.add(new BuiltPlainScalar("amihaiemil"));
-        devs.add(new BuiltPlainScalar("salikjan"));
+        devs.add(new PlainStringScalar("amihaiemil"));
+        devs.add(new PlainStringScalar("salikjan"));
         YamlSequence sequence = sequenceBuilder
             .add("amihaiemil")
             .add(new RtYamlSequence(devs))

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
@@ -88,10 +88,10 @@ public final class RtYamlSequenceTest {
     @Test
     public void sequenceKeepsOrder() {
         List<YamlNode> nodes = new LinkedList<>();
-        BuiltPlainScalar first = new BuiltPlainScalar("test");
-        BuiltPlainScalar sec = new BuiltPlainScalar("mihai");
-        BuiltPlainScalar third = new BuiltPlainScalar("amber");
-        BuiltPlainScalar fourth = new BuiltPlainScalar("5433");
+        PlainStringScalar first = new PlainStringScalar("test");
+        PlainStringScalar sec = new PlainStringScalar("mihai");
+        PlainStringScalar third = new PlainStringScalar("amber");
+        PlainStringScalar fourth = new PlainStringScalar("5433");
         nodes.add(first);
         nodes.add(sec);
         nodes.add(third);
@@ -99,16 +99,16 @@ public final class RtYamlSequenceTest {
         RtYamlSequence seq = new RtYamlSequence(nodes);
         Iterator<YamlNode> ordered = seq.values().iterator();
         MatcherAssert.assertThat(
-            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(first)
+            (PlainStringScalar) ordered.next(), Matchers.equalTo(first)
         );
         MatcherAssert.assertThat(
-            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(sec)
+            (PlainStringScalar) ordered.next(), Matchers.equalTo(sec)
         );
         MatcherAssert.assertThat(
-            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(third)
+            (PlainStringScalar) ordered.next(), Matchers.equalTo(third)
         );
         MatcherAssert.assertThat(
-            (BuiltPlainScalar) ordered.next(), Matchers.equalTo(fourth)
+            (PlainStringScalar) ordered.next(), Matchers.equalTo(fourth)
         );
     }
 
@@ -118,9 +118,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlScalarAsString() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new BuiltPlainScalar("test"));
-        nodes.add(new BuiltPlainScalar("amber"));
-        nodes.add(new BuiltPlainScalar("mihai"));
+        nodes.add(new PlainStringScalar("test"));
+        nodes.add(new PlainStringScalar("amber"));
+        nodes.add(new PlainStringScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
             seq.string(1), Matchers.equalTo("amber")
@@ -136,9 +136,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlMapping() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new BuiltPlainScalar("test"));
+        nodes.add(new PlainStringScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
-        nodes.add(new BuiltPlainScalar("mihai"));
+        nodes.add(new PlainStringScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(
             seq.yamlMapping(1), Matchers.notNullValue()
@@ -151,7 +151,7 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsYamlSequence() {
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new BuiltPlainScalar("test"));
+        nodes.add(new PlainStringScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
         nodes.add(Mockito.mock(YamlSequence.class));
         YamlSequence seq = new RtYamlSequence(nodes);
@@ -169,7 +169,7 @@ public final class RtYamlSequenceTest {
     @Test
     public void comparesToScalar() {
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
-        BuiltPlainScalar scalar = new BuiltPlainScalar("java");
+        PlainStringScalar scalar = new PlainStringScalar("java");
         MatcherAssert.assertThat(
             seq.compareTo(scalar),
             Matchers.greaterThan(0)
@@ -195,10 +195,10 @@ public final class RtYamlSequenceTest {
     @Test
     public void comparesToSequence() {
         List<YamlNode> nodes = new LinkedList<>();
-        BuiltPlainScalar first = new BuiltPlainScalar("test");
-        BuiltPlainScalar sec = new BuiltPlainScalar("mihai");
-        BuiltPlainScalar third = new BuiltPlainScalar("amber");
-        BuiltPlainScalar fourth = new BuiltPlainScalar("5433");
+        PlainStringScalar first = new PlainStringScalar("test");
+        PlainStringScalar sec = new PlainStringScalar("mihai");
+        PlainStringScalar third = new PlainStringScalar("amber");
+        PlainStringScalar fourth = new PlainStringScalar("5433");
         nodes.add(first);
         nodes.add(sec);
         nodes.add(third);
@@ -210,7 +210,7 @@ public final class RtYamlSequenceTest {
         RtYamlSequence another = new RtYamlSequence(nodes);
 
         nodes.remove(0);
-        nodes.add(0, new BuiltPlainScalar("yaml"));
+        nodes.add(0, new PlainStringScalar("yaml"));
         RtYamlSequence sameSize = new RtYamlSequence(nodes);
 
         MatcherAssert.assertThat(seq.compareTo(seq), Matchers.equalTo(0));
@@ -283,9 +283,9 @@ public final class RtYamlSequenceTest {
     @Test
     public void returnsSize(){
         List<YamlNode> nodes = new LinkedList<>();
-        nodes.add(new BuiltPlainScalar("test"));
+        nodes.add(new PlainStringScalar("test"));
         nodes.add(Mockito.mock(YamlMapping.class));
-        nodes.add(new BuiltPlainScalar("mihai"));
+        nodes.add(new PlainStringScalar("mihai"));
         YamlSequence seq = new RtYamlSequence(nodes);
         MatcherAssert.assertThat(seq.size(), Matchers.is(3));
     }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlStreamBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlStreamBuilderTest.java
@@ -41,7 +41,7 @@ import org.mockito.Mockito;
  * @since 3.1.1
  */
 public final class RtYamlStreamBuilderTest {
-    
+
     /**
      * RtYamlStreamBuilder can add a YamlSequence.
      */
@@ -49,14 +49,14 @@ public final class RtYamlStreamBuilderTest {
     public void addsYamlSequence() {
         YamlStreamBuilder streamBuilder = new RtYamlStreamBuilder();
         YamlStreamBuilder withAdded = streamBuilder.add(
-            Mockito.mock(YamlSequence.class)              
+            Mockito.mock(YamlSequence.class)
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             streamBuilder, Matchers.not(Matchers.is(withAdded))
         );
     }
-    
+
     /**
      * RtYamlStreamBuilder can add a YamlMapping.
      */
@@ -64,14 +64,14 @@ public final class RtYamlStreamBuilderTest {
     public void addsYamlMapping() {
         YamlStreamBuilder streamBuilder = new RtYamlStreamBuilder();
         YamlStreamBuilder withAdded = streamBuilder.add(
-            Mockito.mock(YamlMapping.class)              
+            Mockito.mock(YamlMapping.class)
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             streamBuilder, Matchers.not(Matchers.is(withAdded))
         );
     }
-    
+
     /**
      * RtYamlStreamBuilder can add a Scalar.
      */
@@ -79,14 +79,14 @@ public final class RtYamlStreamBuilderTest {
     public void addsScalar() {
         YamlStreamBuilder streamBuilder = new RtYamlStreamBuilder();
         YamlStreamBuilder withAdded = streamBuilder.add(
-            new BuiltPlainScalar("test")            
+            new PlainStringScalar("test")
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             streamBuilder, Matchers.not(Matchers.is(withAdded))
         );
     }
-    
+
     /**
      * RtYamlStreamBuilder can add a YamlNode.
      */
@@ -94,14 +94,14 @@ public final class RtYamlStreamBuilderTest {
     public void addsYamlNode() {
         YamlStreamBuilder streamBuilder = new RtYamlStreamBuilder();
         YamlStreamBuilder withAdded = streamBuilder.add(
-            Mockito.mock(YamlNode.class)              
+            Mockito.mock(YamlNode.class)
         );
         MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
             streamBuilder, Matchers.not(Matchers.is(withAdded))
         );
     }
-    
+
     /**
      * RtYamlStreamBuilder can build the YamlStream.
      */
@@ -112,12 +112,12 @@ public final class RtYamlStreamBuilderTest {
             .add(Mockito.mock(YamlSequence.class))
             .add(Mockito.mock(YamlNode.class))
             .build();
-        
+
         MatcherAssert.assertThat(stream, Matchers.notNullValue());
         MatcherAssert.assertThat(stream, Matchers.instanceOf(Stream.class));
         MatcherAssert.assertThat(
               stream.values(), Matchers.iterableWithSize(3)
         );
     }
-    
+
 }

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -50,9 +50,9 @@ public final class StrictYamlMappingTest {
     @Test
     public void fetchesValues() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));
         YamlMapping map = new StrictYamlMapping(new RtYamlMapping(mappings));
         MatcherAssert.assertThat(
             map.values(), Matchers.not(Matchers.emptyIterable())
@@ -66,9 +66,9 @@ public final class StrictYamlMappingTest {
     @Test
     public void fetchesKeys() {
         Map<YamlNode, YamlNode> mappings = new HashMap<>();
-        mappings.put(new BuiltPlainScalar("key1"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key2"), Mockito.mock(YamlNode.class));
-        mappings.put(new BuiltPlainScalar("key3"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
+        mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));
         YamlMapping map = new StrictYamlMapping(new RtYamlMapping(mappings));
         MatcherAssert.assertThat(
             map.keys(), Matchers.not(Matchers.emptyIterable())
@@ -111,14 +111,14 @@ public final class StrictYamlMappingTest {
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.string("key");
     }
-    
+
     /**
      * StringYamlMapping can throw YamlNodeNotFoundException
      * when the demanded value is not found.
      */
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullValue() {
-        BuiltPlainScalar key = new BuiltPlainScalar("key");
+        PlainStringScalar key = new PlainStringScalar("key");
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         Mockito.when(origin.value(key)).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
@@ -132,7 +132,7 @@ public final class StrictYamlMappingTest {
     public void returnsMapping() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlMapping found = Mockito.mock(YamlMapping.class);
-        YamlNode key = new BuiltPlainScalar("key");
+        YamlNode key = new PlainStringScalar("key");
         Mockito.when(origin.yamlMapping(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
@@ -147,7 +147,7 @@ public final class StrictYamlMappingTest {
     public void returnsSequence() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlSequence found = Mockito.mock(YamlSequence.class);
-        YamlNode key = new BuiltPlainScalar("key");
+        YamlNode key = new PlainStringScalar("key");
         Mockito.when(origin.yamlSequence(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
@@ -161,22 +161,22 @@ public final class StrictYamlMappingTest {
     @Test
     public void returnsString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        YamlNode key = new BuiltPlainScalar("key");
+        YamlNode key = new PlainStringScalar("key");
         Mockito.when(origin.string(key)).thenReturn("found");
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.string("key"), Matchers.equalTo("found")
         );
     }
-    
+
     /**
      * StringYamlMapping can fetch a value based in its key.
      */
     @Test
     public void returnsValue() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        YamlNode key = new BuiltPlainScalar("key");
-        YamlNode value = new BuiltPlainScalar("value");
+        YamlNode key = new PlainStringScalar("key");
+        YamlNode value = new PlainStringScalar("value");
         Mockito.when(origin.value(key)).thenReturn(value);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
@@ -48,9 +48,9 @@ public final class StrictYamlSequenceTest {
     @Test
     public void fetchesValues() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new BuiltPlainScalar("key1"));
-        elements.add(new BuiltPlainScalar("key2"));
-        elements.add(new BuiltPlainScalar("key3"));
+        elements.add(new PlainStringScalar("key1"));
+        elements.add(new PlainStringScalar("key2"));
+        elements.add(new PlainStringScalar("key3"));
         YamlSequence sequence = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );
@@ -67,9 +67,9 @@ public final class StrictYamlSequenceTest {
     @Test
     public void strictSequenceIsIterable() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new BuiltPlainScalar("key1"));
-        elements.add(new BuiltPlainScalar("key2"));
-        elements.add(new BuiltPlainScalar("key3"));
+        elements.add(new PlainStringScalar("key1"));
+        elements.add(new PlainStringScalar("key2"));
+        elements.add(new PlainStringScalar("key3"));
         YamlSequence seq = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );
@@ -119,8 +119,8 @@ public final class StrictYamlSequenceTest {
     @Test
     public void returnsSize() {
         List<YamlNode> elements = new LinkedList<>();
-        elements.add(new BuiltPlainScalar("key1"));
-        elements.add(new BuiltPlainScalar("key2"));
+        elements.add(new PlainStringScalar("key1"));
+        elements.add(new PlainStringScalar("key2"));
         YamlSequence sequence = new StrictYamlSequence(
             new RtYamlSequence(elements)
         );


### PR DESCRIPTION
PR for #221 

Just a renaming. The BuiltPlainScalar name didn't make sense in all the contexts where this class was used.