### PR TITLE
Building of Plain Scalars Implemented

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
@@ -28,7 +28,7 @@
 package com.amihaiemil.eoyaml;
 
 /**
- * A plain scalar value read from a read mapping or a read sequence.
+ * A plain scalar value read from somewhere.
  * @author Mihai Andronace (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.3
@@ -39,7 +39,8 @@ final class ReadPlainScalarValue extends ComparableScalar {
      * Line where the plain scalar value is supposed to be found.
      * The Scalar can be either after the ":" character, if this
      * line is from a mapping, or after the "-" character, if
-     * this line is from a sequence.
+     * this line is from a sequence, or it represents the whole line,
+     * if no "-" or ":" are found.
      */
     private YamlLine line;
 

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Implementation for {@link YamlInput}.
+ * Implementation for {@link YamlInput}. "Rt" stands for "Runtime".
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
@@ -29,6 +29,7 @@ package com.amihaiemil.eoyaml;
 
 /**
  * Default implementation of {@link YamlLine}.
+ * "Rt" stands for "Runtime".
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
@@ -31,7 +31,7 @@ import java.util.HashMap;
 import java.util.Map;
 
 /**
- * YamlMappingBuilder implementation.
+ * YamlMappingBuilder implementation. "Rt" stands for "Runtime".
  * This class is immutable and thread-safe.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
@@ -27,56 +27,67 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.util.LinkedList;
+import java.util.List;
+import java.util.stream.Collectors;
+
 /**
- * Builder of Yaml Scalar. Implementations should be immutable and thread-safe.
+ * Implementation for {@link YamlScalarBuilder}. "Rt" stands for "Runtime.
+ * This class is immutable and thread-safe.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.2.0
+ * @todo #221:30min Finish the implementation of the methods in this interface.
+ *  Figure out how to implement literal and built block scalars, also in the
+ *  the context of indenting/printing a bigger YAML node, as well as printing
+ *  only that single scalar. Maybe we will need a class called YamlPrinter,
+ *  that looks for the type of the node to print.
  */
-public interface YamlScalarBuilder {
+final class RtYamlScalarBuilder implements YamlScalarBuilder {
 
     /**
-     * Add a line of text this Scalar. You can use this multiple
-     * times or just once, if your String already contains NEW_LINE
-     * chars.
-     * @param value String
-     * @return An instance of this builder.
+     * Added lines.
      */
-    YamlScalarBuilder addLine(final String value);
+    private final List<String> lines;
 
     /**
-     * Build a plain Scalar. Ideally, you should use this when
-     * your scalar is short, a single line of text.<br><br>
-     * If you added more lines of text, all of them will be put together,
-     * separated by spaces.
-     * @return The built Scalar.
+     * Default ctor.
      */
-    Scalar buildPlainScalar();
+    RtYamlScalarBuilder() {
+        this(new LinkedList<>());
+    }
 
     /**
-     * Build a Folded Block Scalar. Use this when your scalar has multiple
-     * lines of text, but you don't care about the newlines, you want them
-     * all separated by spaces. <br><br>
-     *
-     * The difference from buildPlainScalar() comes when you are printing
-     * the created YAML:
-     * <pre>
-     *     plain: a very long scalar which should have been built as Folded
-     *     folded:>
-     *       a very long scalar which
-     *       has been folded for readability
-     * </pre>
-     *
-     * @return The built Scalar.
+     * Constructor.
+     * @param lines String lines of the Scalar.
      */
-    Scalar buildFoldedBlockScalar();
+    RtYamlScalarBuilder(final List<String> lines) {
+        this.lines = lines;
+    }
 
-    /**
-     * Build a Literal Block Scalar. Use this when your scalar has multiple
-     * lines and you want these lines to be separated.
-     *
-     * @return The built Scalar.
-     */
-    Scalar buildLiteralBlockScalar();
+    @Override
+    public YamlScalarBuilder addLine(final String value) {
+        final List<String> all = new LinkedList<>();
+        all.addAll(this.lines);
+        all.add(value);
+        return new RtYamlScalarBuilder(all);
+    }
 
+    @Override
+    public Scalar buildPlainScalar() {
+        final String plain = this.lines.stream().map(
+            line -> line.replaceAll(System.lineSeparator(), " ")
+        ).collect(Collectors.joining(" "));
+        return new PlainStringScalar(plain);
+    }
+
+    @Override
+    public Scalar buildFoldedBlockScalar() {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
+
+    @Override
+    public Scalar buildLiteralBlockScalar() {
+        throw new UnsupportedOperationException("Not yet implemented.");
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
@@ -36,7 +36,7 @@ import java.util.stream.Collectors;
  * This class is immutable and thread-safe.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 3.2.0
+ * @since 4.0.0
  * @todo #221:30min Finish the implementation of the methods in this interface.
  *  Figure out how to implement literal and built block scalars, also in the
  *  the context of indenting/printing a bigger YAML node, as well as printing

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -31,7 +31,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * YamlSequenceBuilder implementation.
+ * YamlSequenceBuilder implementation. "Rt" stands for "Runtime".
  * This class is immutable and thread-safe.
  * @author Salavat.Yalalov (s.yalalov@gmail.com)
  * @version $Id$

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlStreamBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlStreamBuilder.java
@@ -32,7 +32,7 @@ import java.util.LinkedList;
 import java.util.List;
 
 /**
- * YamlStreamBuilder implementation.
+ * YamlStreamBuilder implementation. "Rt" stands for "Runtime".
  * This class is immutable and thread-safe.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$

--- a/src/main/java/com/amihaiemil/eoyaml/Yaml.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Yaml.java
@@ -62,7 +62,15 @@ public final class Yaml {
     public static YamlSequenceBuilder createYamlSequenceBuilder() {
         return new RtYamlSequenceBuilder();
     }
-    
+
+    /**
+     * Create a {@link YamlScalarBuilder}.
+     * @return Builder of Yaml Scalars.
+     */
+    public static YamlScalarBuilder createYamlScalarBuilder() {
+        return new RtYamlScalarBuilder();
+    }
+
     /**
      * Create a {@link YamlStreamBuilder}.
      * @return Builder of YamlStream.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
@@ -31,7 +31,7 @@ package com.amihaiemil.eoyaml;
  * Builder of Yaml Scalar. Implementations should be immutable and thread-safe.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 3.2.0
+ * @since 4.0.0
  */
 public interface YamlScalarBuilder {
 

--- a/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
@@ -1,0 +1,55 @@
+package com.amihaiemil.eoyaml;
+
+/**
+ * Builder of Yaml Scalar. Implementations should be immutable and thread-safe.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 3.2.0
+ */
+public interface YamlScalarBuilder {
+
+    /**
+     * Add a line of text this Scalar. You can use this multiple
+     * times or just once, if your String already contains NEW_LINE
+     * chars.
+     * @param value String
+     * @return An instance of this builder.
+     */
+    YamlScalarBuilder addLine(final String value);
+
+    /**
+     * Build a plain Scalar. Ideally, you should use this when
+     * your scalar is short, a single line of text.<br><br>
+     * If you added more lines of text, all of them will be put together,
+     * separated by spaces.
+     * @return The built Scalar.
+     */
+    Scalar buildPlainScalar();
+
+    /**
+     * Build a Folded Block Scalar. Use this when your scalar has multiple
+     * lines of text, but you don't care about the newlines, you want them
+     * all separated by spaces. <br><br>
+     *
+     * The difference from buildPlainScalar() comes when you are printing
+     * the created YAML:
+     * <pre>
+     *     plain: a very long scalar which should have been built as Folded
+     *     folded:>
+     *       a very long scalar which
+     *       has been folded for readability
+     * </pre>
+     *
+     * @return The built Scalar.
+     */
+    Scalar buildFoldedBlockScalar();
+
+    /**
+     * Build a Literal Block Scalar. Use this when your scalar has multiple
+     * lines and you want these lines to be separated.
+     *
+     * @return The built Scalar.
+     */
+    Scalar buildLiteralBlockScalar();
+
+}

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlScalarBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlScalarBuilderTest.java
@@ -27,95 +27,86 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.io.ByteArrayInputStream;
-import java.io.File;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
 
 /**
- * Unit tests for {@link Yaml}.
+ * Unit tests for {@link RtYamlScalarBuilder}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 1.0.0
+ * @since 4.0.0
  */
-public final class YamlTest {
+public final class RtYamlScalarBuilderTest {
 
     /**
-     * Yaml can create a YamlMappingBuilder.
+     * RtYamlScalarBuilder can add line of text.
      */
     @Test
-    public void createsYamlMappingBuilder() {
+    public void addsLineOfText() {
+        final YamlScalarBuilder scalarBuilder = new RtYamlScalarBuilder();
+        final YamlScalarBuilder withAdded = scalarBuilder.addLine("a scalar");
+        MatcherAssert.assertThat(withAdded, Matchers.notNullValue());
         MatcherAssert.assertThat(
-            Yaml.createYamlMappingBuilder(), Matchers.notNullValue()
+            scalarBuilder, Matchers.not(Matchers.is(withAdded))
         );
     }
 
     /**
-     * Yaml can create a YamlSequenceBuilder.
+     * RtYamlScalarBuilder can build a plain scalar with no newlines.
+     * @checkstyle LineLength (30 lines)
      */
     @Test
-    public void createsYamlSequenceBuilder() {
+    public void buildsPlainScalarNoNewLines() {
+        final Scalar scalar = new RtYamlScalarBuilder()
+            .addLine("a plain scalar")
+            .addLine("that will be on the same line")
+            .buildPlainScalar();
         MatcherAssert.assertThat(
-            Yaml.createYamlSequenceBuilder(), Matchers.notNullValue()
+            scalar.value(), Matchers.equalTo("a plain scalar that will be on the same line")
         );
     }
 
     /**
-     * Yaml can create a YamlScalarBuilder.
+     * RtYamlScalarBuilder can build a plain scalar, while removing
+     * the hardcoded newlines.
+     * @checkstyle LineLength (30 lines)
      */
     @Test
-    public void createsYamlScalarBuilder() {
+    public void buildsPlainScalarRemovesAddedNewLines() {
+        final Scalar scalar = new RtYamlScalarBuilder()
+            .addLine("a plain scalar")
+            .addLine("that will be" + System.lineSeparator() + "on the same line.")
+            .addLine("You cannot trick it.")
+            .buildPlainScalar();
         MatcherAssert.assertThat(
-            Yaml.createYamlScalarBuilder(), Matchers.notNullValue()
+            scalar.value(),
+            Matchers.equalTo("a plain scalar that will be on the same line. You cannot trick it.")
         );
     }
 
     /**
-     * Yaml can create a YamlStreamBuilder.
+     * RtYamlScalarBuilder can build on a single line of text.
      */
     @Test
-    public void createsYamlStreamBuilder() {
+    public void buildsSingleLinePlainScalar() {
+        final Scalar scalar = new RtYamlScalarBuilder()
+            .addLine("value").buildPlainScalar();
         MatcherAssert.assertThat(
-            Yaml.createYamlStreamBuilder(), Matchers.notNullValue()
+            scalar.value(),
+            Matchers.equalTo("value")
         );
     }
 
     /**
-     * Yaml can create a YamlInput from a File.
-     * @throws Exception if something goes wrong
+     * RtYamlScalarBuilder can build an empty plain scalar.
      */
     @Test
-    public void createsYamlInputFromFile() throws Exception {
+    public void buildsEmptyPlainScalar() {
+        final Scalar scalar = new RtYamlScalarBuilder().buildPlainScalar();
         MatcherAssert.assertThat(
-            Yaml.createYamlInput(
-                new File("src/test/resources/simpleMapping.yml")
-            ),
-            Matchers.notNullValue()
-        );
-    }
-
-    /**
-     * Yaml can create a YamlInput from an InputStream.
-     */
-    @Test
-    public void createsYamlInputFromInputStream() {
-        MatcherAssert.assertThat(
-            Yaml.createYamlInput(
-                new ByteArrayInputStream("yaml: test".getBytes())
-            ),
-            Matchers.notNullValue()
-        );
-    }
-
-    /**
-     * Yaml can create a YamlInput from a String.
-     */
-    @Test
-    public void createsYamlInputFromString() {
-        MatcherAssert.assertThat(
-            Yaml.createYamlInput("yaml: test"), Matchers.notNullValue()
+            scalar.value(),
+            Matchers.isEmptyString()
         );
     }
 }


### PR DESCRIPTION
Fixes #221 
 
* Added ``YamlScalarBuilder`` interface and method ``Yaml.createYamlScalarBuilder()``
* Added implementation ``RtYamlScalarBuilder``
* Implemented ``RtYamlScalarBuilder.buildPlainScalar()``
* Added unit tests
* Left puzzle to continue development of ``buildFolded/LiteralBlockScalar()`` in the next Issue
* Some javadoc fixes across the ``Rt*`` classes