### PR TITLE
Fixed toString() for Scalars

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/BaseScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseScalar.java
@@ -100,10 +100,14 @@ abstract class BaseScalar extends BaseYamlNode implements Scalar {
         return result;
     }
 
-    @Override
-    public String toString() {
-        return this.indent(0);
-    }
+    /**
+     * This has to be overridden by all Scalars. When printing a single scalar,
+     * it is not enough to just print its value (this.indent(0)), it has to
+     * be wrapped in a YAML Document, otherwise the print
+     * won't be a valid YAML.
+     * @return String.
+     */
+    public abstract String toString();
 
     /**
      * Indent this scalar. Keep this method package-protected, it should

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
@@ -204,4 +204,14 @@ abstract class BaseYamlMapping extends BaseYamlNode implements YamlMapping {
         }
         return printed;
     }
+
+    /**
+     * When printing a YamlMapping we dimply call this.indent(0), no need
+     * to add other stuff.
+     * @return This printed mapping.
+     */
+    @Override
+    public final String toString() {
+        return this.indent(0);
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
@@ -151,7 +151,7 @@ abstract class BaseYamlMapping extends BaseYamlNode implements YamlMapping {
      *  YamlNodes, this value may be greater than 0.
      * @return String indented YamlMapping, by the specified indentation.
      */
-    String indent(final int indentation) {
+    final String indent(final int indentation) {
         if(indentation < 0) {
             throw new IllegalArgumentException(
                 "Indentation level has to be >=0"
@@ -167,11 +167,12 @@ abstract class BaseYamlMapping extends BaseYamlNode implements YamlMapping {
         }
         for(final YamlNode key : this.keys()) {
             print.append(indent);
+            final BaseYamlNode indKey = (BaseYamlNode) key;
             final BaseYamlNode value = (BaseYamlNode) this.value(key);
-            if(key instanceof Scalar) {
-                print.append(key.toString()).append(": ");
+            if(indKey instanceof Scalar) {
+                print.append(indKey.indent(0)).append(": ");
                 if (value instanceof Scalar) {
-                    print.append(value.toString()).append(newLine);
+                    print.append(value.indent(0)).append(newLine);
                 } else  {
                     print
                         .append(newLine)
@@ -179,7 +180,6 @@ abstract class BaseYamlMapping extends BaseYamlNode implements YamlMapping {
                         .append(newLine);
                 }
             } else {
-                final BaseYamlNode indKey = (BaseYamlNode) key;
                 print
                     .append("?")
                     .append(newLine)
@@ -189,7 +189,7 @@ abstract class BaseYamlMapping extends BaseYamlNode implements YamlMapping {
                     .append(":");
                 if(value instanceof Scalar) {
                     print
-                        .append(" ").append(value);
+                        .append(" ").append(value.indent(0));
                 } else {
                     print
                         .append(newLine)

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlNode.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlNode.java
@@ -38,6 +38,13 @@ abstract class BaseYamlNode implements YamlNode {
 
     /**
      * Print this YAML node with the given indentation.
+     * When implementing this method, make sure to only use
+     * the indent(...) method on children node.
+     *
+     * Never use toString() when indenting. toString() is supposed
+     * to be the final printing method for any YamlNode. E.g. in the
+     * case of Scalars, toString() does more than just indentation.
+     *
      * @param indentation Indentation. Has to be >=0.
      * @throws IllegalStateException If the given indentation is < 0.
      * @return Indented String.

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
@@ -134,7 +134,7 @@ abstract class BaseYamlSequence extends BaseYamlNode implements YamlSequence {
      *  YamlNodes, this value may be greater than 0.
      * @return String indented YamlSequence, by the specified indentation.
      */
-    String indent(final int indentation) {
+    final String indent(final int indentation) {
         if(indentation < 0) {
             throw new IllegalArgumentException(
                 "Indentation level has to be >=0"
@@ -152,8 +152,8 @@ abstract class BaseYamlSequence extends BaseYamlNode implements YamlSequence {
             final BaseYamlNode indentable = (BaseYamlNode) node;
             print.append(indent)
                 .append("- ");
-            if (node instanceof Scalar) {
-                print.append(node.toString()).append(newLine);
+            if (indentable instanceof Scalar) {
+                print.append(indentable.indent(0)).append(newLine);
             } else  {
                 print
                     .append(newLine)

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
@@ -168,4 +168,13 @@ abstract class BaseYamlSequence extends BaseYamlNode implements YamlSequence {
         return printed;
     }
 
+    /**
+     * When printing a YamlSequence, just call this.indent(0), no need for
+     * other wrappers.
+     * @return This printed YamlSequence.
+     */
+    @Override
+    public final String toString() {
+        return this.indent(0);
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlStream.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlStream.java
@@ -123,11 +123,6 @@ abstract class BaseYamlStream extends BaseYamlNode implements YamlStream {
         return result;
     }
 
-    @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
     /**
      * Indent this YamlStream. It will take all elements and separate
      * them with "---". It also starts with "---".
@@ -196,5 +191,14 @@ abstract class BaseYamlStream extends BaseYamlNode implements YamlStream {
             }
         }
         return printed;
+    }
+
+    /**
+     * When printing a stream just indent it to 0, no need for other wrappers.
+     * @return Printed stream of YAML Documents
+     */
+    @Override
+    public final String toString() {
+        return this.indent(0);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlStream.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlStream.java
@@ -154,7 +154,7 @@ abstract class BaseYamlStream extends BaseYamlNode implements YamlStream {
      *  be nested within a bigger YAML.
      * @return String.
      */
-    String indent(final int indentation) {
+    final String indent(final int indentation) {
         if(indentation < 0) {
             throw new IllegalArgumentException(
                 "Indentation level has to be >=0"

--- a/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
@@ -62,4 +62,25 @@ final class PlainStringScalar extends BaseScalar {
     public String value() {
         return this.value;
     }
+
+    /**
+     * When printing a plain scalar, we have to wrap it
+     * inside proper YAML elements, otherwise it won't make
+     * sense as a YAML document. It will look like this:
+     * <pre>
+     * ---
+     * scalar
+     * ...
+     * </pre>
+     * @return This scalar as a YAML document.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder string = new StringBuilder();
+        string
+            .append("---").append(System.lineSeparator())
+            .append(this.indent(0))
+            .append("...");
+        return string.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
@@ -79,7 +79,7 @@ final class PlainStringScalar extends BaseScalar {
         final StringBuilder string = new StringBuilder();
         string
             .append("---").append(System.lineSeparator())
-            .append(this.indent(0))
+            .append(this.indent(0)).append(System.lineSeparator())
             .append("...");
         return string.toString();
     }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
@@ -125,4 +125,27 @@ final class ReadFoldedBlockScalar extends BaseScalar {
         return builder.toString();
     }
 
+    /**
+     * When printing a folded scalar, we have to wrap it
+     * inside proper YAML elements, otherwise it won't make
+     * sense as a YAML document. It will look like this:
+     * <pre>
+     * ---
+     * >
+     *   some folded
+     *   scalar on more lines
+     * ...
+     * </pre>
+     * @return This scalar as a YAML document.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder string = new StringBuilder();
+        string.append("---").append(System.lineSeparator())
+            .append(">").append(System.lineSeparator())
+            .append(this.indent(2))
+            .append(System.lineSeparator())
+            .append("...");
+        return string.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
@@ -87,4 +87,28 @@ final class ReadLiteralBlockScalar extends BaseScalar {
         return builder.toString();
     }
 
+    /**
+     * When printing a literal scalar, we have to wrap it
+     * inside proper YAML elements, otherwise it won't make
+     * sense as a YAML document. It will look like this:
+     * <pre>
+     * ---
+     * |
+     *   line1
+     *   line2
+     *   line3
+     * ...
+     * </pre>
+     * @return This scalar as a YAML document.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder string = new StringBuilder();
+        string.append("---").append(System.lineSeparator())
+            .append("|").append(System.lineSeparator())
+            .append(this.indent(2))
+            .append(System.lineSeparator())
+            .append("...");
+        return string.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarKey.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarKey.java
@@ -66,4 +66,9 @@ final class ReadPlainScalarKey extends BaseScalar {
                 + "Instead, the line is: [" + this.line.trimmed() + "]."
         );
     }
+
+    @Override
+    public String toString() {
+        return this.indent(0);
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
@@ -104,7 +104,7 @@ final class ReadPlainScalarValue extends BaseScalar {
         final StringBuilder string = new StringBuilder();
         string
             .append("---").append(System.lineSeparator())
-            .append(this.indent(0))
+            .append(this.indent(0)).append(System.lineSeparator())
             .append("...");
         return string.toString();
     }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalarValue.java
@@ -87,4 +87,25 @@ final class ReadPlainScalarValue extends BaseScalar {
         }
         return unescaped;
     }
+
+    /**
+     * When printing a plain scalar, we have to wrap it
+     * inside proper YAML elements, otherwise it won't make
+     * sense as a YAML document. It will look like this:
+     * <pre>
+     * ---
+     * scalar
+     * ...
+     * </pre>
+     * @return This scalar as a YAML document.
+     */
+    @Override
+    public String toString() {
+        final StringBuilder string = new StringBuilder();
+        string
+            .append("---").append(System.lineSeparator())
+            .append(this.indent(0))
+            .append("...");
+        return string.toString();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -169,11 +169,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
         return value;
     }
 
-    @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
     /**
      * The YamlNode value associated with a String (scalar) key.
      * @param key String key.

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -73,11 +73,6 @@ final class ReadYamlSequence extends BaseYamlSequence {
     }
 
     @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
-    @Override
     public YamlMapping yamlMapping(final int index) {
         YamlMapping mapping = null;
         int count = 0;

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -109,11 +109,6 @@ final class RtYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
-    @Override
     public Set<YamlNode> keys() {
         final Set<YamlNode> keys = new TreeSet<>();
         keys.addAll(this.mappings.keySet());

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
@@ -167,5 +167,44 @@ final class RtYamlScalarBuilder implements YamlScalarBuilder {
             }
             return print.toString();
         }
+
+        /**
+         * When printing a block scalar, we have to wrap it
+         * inside proper YAML elements, otherwise it won't make
+         * sense as a YAML document. It will look like this (folded):
+         * <pre>
+         * ---
+         * >
+         *   some folded
+         *   scalar on more lines
+         * ...
+         * </pre>
+         * and literal:
+         * <pre>
+         * ---
+         * |
+         *   line 1
+         *   line 2
+         *   line 3
+         * ...
+         * </pre>
+         * @return This scalar as a YAML document.
+         */
+        @Override
+        public String toString() {
+            final StringBuilder string = new StringBuilder();
+            string.append("---").append(System.lineSeparator());
+            if(this.folded) {
+                string.append(">");
+            } else {
+                string.append("|");
+            }
+            string
+                .append(System.lineSeparator())
+                .append(this.indent(2))
+                .append(System.lineSeparator())
+                .append("...");
+            return string.toString();
+        }
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
@@ -98,11 +98,6 @@ final class RtYamlSequence extends BaseYamlSequence {
     }
 
     @Override
-    public String toString() {
-        return this.indent(0);
-    }
-
-    @Override
     public int size() {
         return this.nodes.size();
     }

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -110,11 +110,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String toString() {
-        return this.decorated.toString();
-    }
-
-    @Override
     public Set<YamlNode> keys() {
         return this.decorated.keys();
     }

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
@@ -108,11 +108,6 @@ public final class StrictYamlSequence extends BaseYamlSequence {
     }
 
     @Override
-    public String toString() {
-        return this.decorated.toString();
-    }
-
-    @Override
     public int size() {
         return this.decorated.size();
     }

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltBlockScalarTest.java
@@ -124,4 +124,53 @@ public final class BuiltBlockScalarTest {
         );
     }
 
+    /**
+     * Method toString should print it as a valid YAML document.
+     */
+    @Test
+    public void toStringPrintsYaml() {
+        final List<String> lines = new ArrayList<>();
+        lines.add("line1");
+        lines.add("line2");
+        lines.add("line3");
+        final Scalar folded = new RtYamlScalarBuilder.BuiltBlockScalar(
+            lines, true
+        );
+        MatcherAssert.assertThat(
+            folded.toString(),
+            Matchers.equalTo(
+                "---"
+                + System.lineSeparator()
+                + ">"
+                + System.lineSeparator()
+                + "  line1"
+                + System.lineSeparator()
+                + "  line2"
+                + System.lineSeparator()
+                + "  line3"
+                + System.lineSeparator()
+                + "..."
+            )
+        );
+        final Scalar literal = new RtYamlScalarBuilder.BuiltBlockScalar(
+            lines, false
+        );
+        MatcherAssert.assertThat(
+            literal.toString(),
+            Matchers.equalTo(
+            "---"
+                + System.lineSeparator()
+                + "|"
+                + System.lineSeparator()
+                + "  line1"
+                + System.lineSeparator()
+                + "  line2"
+                + System.lineSeparator()
+                + "  line3"
+                + System.lineSeparator()
+                + "..."
+            )
+        );
+    }
+
 }

--- a/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
@@ -120,4 +120,22 @@ public final class PlainStringScalarTest {
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(first.compareTo(seq), Matchers.lessThan(0));
     }
+
+    /**
+     * Method toString should print it as a valid YAML document.
+     */
+    @Test
+    public void toStringPrintsYaml() {
+        final Scalar scalar = new PlainStringScalar("value");
+        MatcherAssert.assertThat(
+            scalar.toString(),
+            Matchers.equalTo(
+            "---"
+                + System.lineSeparator()
+                + "value"
+                + System.lineSeparator()
+                + "..."
+            )
+        );
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
@@ -33,6 +33,7 @@ import java.util.LinkedList;
 import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -209,6 +210,42 @@ public final class ReadFoldedBlockScalarTest {
                 + "      63 Home Runs"
                 + System.lineSeparator()
                 + "    What a year!"
+            )
+        );
+    }
+
+    /**
+     * Method toString should print it as a valid YAML document.
+     * @todo #229:30min Fix method ReadFoldedBlockScalar.indent(...).
+     *  At the moment, it folds the scalar when indenting, but this is
+     *  not correct. Indentation is for printing and when we're printing
+     *  a Folded Scalar, it should be printed as a block. It is only
+     *  method value() that should return the folded version.
+     */
+    @Test
+    @Ignore
+    public void toStringPrintsYaml() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("First Line", 0));
+        lines.add(new RtYamlLine("Second Line", 1));
+        lines.add(new RtYamlLine("Third Line", 2));
+        final Scalar scalar =
+            new ReadFoldedBlockScalar(new AllYamlLines(lines));
+        System.out.print(scalar);
+        MatcherAssert.assertThat(
+            scalar.toString(),
+            Matchers.equalTo(
+            "---"
+                + System.lineSeparator()
+                + ">"
+                + System.lineSeparator()
+                + "  First Line"
+                + System.lineSeparator()
+                + "  Second Line"
+                + System.lineSeparator()
+                + "  Third Line"
+                + System.lineSeparator()
+                + "..."
             )
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
@@ -144,4 +144,33 @@ public final class ReadLiteralBlockScalarTest {
             )
         );
     }
+
+    /**
+     * Method toString should print it as a valid YAML document.
+     */
+    @Test
+    public void toStringPrintsYaml() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("First Line", 0));
+        lines.add(new RtYamlLine("Second Line", 1));
+        lines.add(new RtYamlLine("Third Line", 2));
+        final Scalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
+        MatcherAssert.assertThat(
+            scalar.toString(),
+            Matchers.equalTo(
+            "---"
+                + System.lineSeparator()
+                + "|"
+                + System.lineSeparator()
+                + "  First Line"
+                + System.lineSeparator()
+                + "  Second Line"
+                + System.lineSeparator()
+                + "  Third Line"
+                + System.lineSeparator()
+                + "..."
+            )
+        );
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarKeyTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarKeyTest.java
@@ -111,4 +111,15 @@ public final class ReadPlainScalarKeyTest {
         scalar.value();
         Assert.fail("IllegalStateException was expected.");
     }
+
+    /**
+     * Unit test for toString.
+     */
+    @Test
+    public void toStringWorks() {
+        final Scalar scalar = new ReadPlainScalarKey(
+            new RtYamlLine("key: value", 0)
+        );
+        MatcherAssert.assertThat(scalar.toString(), Matchers.equalTo("key"));
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarValueTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarValueTest.java
@@ -82,4 +82,24 @@ public final class ReadPlainScalarValueTest {
         final Scalar scalar = new ReadPlainScalarValue(line);
         MatcherAssert.assertThat(scalar.value(), Matchers.isEmptyString());
     }
+
+    /**
+     * Unit test for toString.
+     */
+    @Test
+    public void toStringWorks() {
+        final Scalar scalar = new ReadPlainScalarValue(
+            new RtYamlLine("key: value", 0)
+        );
+        MatcherAssert.assertThat(
+            scalar.toString(),
+            Matchers.equalTo(
+            "---"
+                + System.lineSeparator()
+                + "value"
+                + System.lineSeparator()
+                + "..."
+            )
+        );
+    }
 }


### PR DESCRIPTION
Fixes #229 

* revised toString for mappings, sequences and streams. A final toString() in the base class is ok
* added toString() implementations for all types of Scalar, to print them as YAML documents. So far, if a single Scalar was being printed, the resulted string wasn't actually a valid YAML.
* Made sure that all ``indent(...)`` methods call only other ``indent(...)`` methods, never toString().
* Left javadocs.
* added unit tests for the Scalar toString methods and left puzzle to fix a small bug in ReadFoldedBlockScalar