### PR TITLE
ReadFoldedBlockScalar.indent() fixed

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalar.java
@@ -27,6 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
+
 /**
  * Read Yaml folded block Scalar. This is a Scalar spanning multiple lines.
  * This Scalar's newlines will be ignored ("folded"), the scalar's value
@@ -59,33 +60,20 @@ final class ReadFoldedBlockScalar extends BaseScalar {
 
     @Override
     String indent(final int indentation) {
-        StringBuilder builder = new StringBuilder();
-        final String newLine = System.lineSeparator();
-        for(final YamlLine line: this.lines) {
-            if(line.trimmed().length() == 0 || line.indentation() > 0) {
-                if(this.doNotEndWithNewLine(builder)) {
-                    builder.append(newLine);
-                }
-                int spaces = line.indentation();
-                if(spaces > 0) {
-                    for(int i = 0; i < spaces + indentation; i++) {
-                        builder.append(' ');
-                    }
-                }
-                builder.append(line.trimmed());
-                builder.append(newLine);
-            } else {
-                if(this.doNotEndWithNewLine(builder)) {
-                    builder.append(' ');
-                } else {
-                    for(int i = 0; i < indentation; i++) {
-                        builder.append(' ');
-                    }
-                }
-                builder.append(line.trimmed());
-            }
+        StringBuilder alignment = new StringBuilder();
+        int spaces = indentation;
+        while (spaces > 0) {
+            alignment.append(" ");
+            spaces--;
         }
-        return builder.toString();
+        StringBuilder printed = new StringBuilder();
+        for(final YamlLine line: this.lines) {
+            printed.append(alignment);
+            printed.append(line.trimmed());
+            printed.append(System.lineSeparator());
+        }
+        printed.delete(printed.length()-1, printed.length());
+        return printed.toString();
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalar.java
@@ -59,13 +59,15 @@ final class ReadLiteralBlockScalar extends BaseScalar {
 
     @Override
     String indent(final int indentation) {
+        StringBuilder alignment = new StringBuilder();
+        int spaces = indentation;
+        while (spaces > 0) {
+            alignment.append(" ");
+            spaces--;
+        }
         StringBuilder printed = new StringBuilder();
         for(final YamlLine line: this.lines) {
-            int spaces = indentation;
-            while (spaces > 0) {
-                printed.append(" ");
-                spaces--;
-            }
+            printed.append(alignment);
             printed.append(line.trimmed());
             printed.append(System.lineSeparator());
         }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
@@ -33,7 +33,6 @@ import java.util.LinkedList;
 import java.util.List;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -169,61 +168,32 @@ public final class ReadFoldedBlockScalarTest {
             )
         );
     }
-    /**
-     * ReadPointedScalar can indent a simple folded scalar.
-     */
-    @Test
-    public void indentsFoldedValue() {
-        final List<YamlLine> lines = new ArrayList<>();
-        lines.add(new RtYamlLine("Mark McGwire's", 1));
-        lines.add(new RtYamlLine("year was crippled", 2));
-        lines.add(new RtYamlLine("by an injury.", 3));
-        final ReadFoldedBlockScalar scalar =
-            new ReadFoldedBlockScalar(new AllYamlLines(lines));
-        MatcherAssert.assertThat(
-            scalar.indent(4),
-            Matchers.is("    Mark McGwire's year was crippled by an injury.")
-        );
-    }
 
     /**
-     * ReadPointedScalar can indent a scalar with
-     * preserved folded newlines and blank lines.
+     * Indentation works fine.
      */
     @Test
-    public void indentsFoldedNewlinesAndBlankLines() {
+    public void indentsValue() {
         final List<YamlLine> lines = new ArrayList<>();
-        lines.add(new RtYamlLine("Sammy Sosa completed another", 1));
-        lines.add(new RtYamlLine("fine season with great stats.", 2));
-        lines.add(new RtYamlLine("", 3));
-        lines.add(new RtYamlLine("  63 Home Runs", 4));
-        lines.add(new RtYamlLine("What a year!", 5));
-        final ReadFoldedBlockScalar scalar =
-            new ReadFoldedBlockScalar(new AllYamlLines(lines));
+        lines.add(new RtYamlLine("First Line.", 1));
+        lines.add(new RtYamlLine("Second Line.", 2));
+        lines.add(new RtYamlLine("Third Line.", 3));
+        final ReadLiteralBlockScalar scalar =
+            new ReadLiteralBlockScalar(new AllYamlLines(lines));
         MatcherAssert.assertThat(
             scalar.indent(4),
             Matchers.is(
-                "    Sammy Sosa completed another "
-                + "fine season with great stats."
-                + System.lineSeparator()
-                + System.lineSeparator()
-                + "      63 Home Runs"
-                + System.lineSeparator()
-                + "    What a year!"
+                "    First Line." + System.lineSeparator()
+                    + "    Second Line." + System.lineSeparator()
+                    + "    Third Line."
             )
         );
     }
 
     /**
      * Method toString should print it as a valid YAML document.
-     * @todo #229:30min Fix method ReadFoldedBlockScalar.indent(...).
-     *  At the moment, it folds the scalar when indenting, but this is
-     *  not correct. Indentation is for printing and when we're printing
-     *  a Folded Scalar, it should be printed as a block. It is only
-     *  method value() that should return the folded version.
      */
     @Test
-    @Ignore
     public void toStringPrintsYaml() {
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("First Line", 0));

--- a/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
@@ -125,7 +125,7 @@ public final class ReadLiteralBlockScalarTest {
     }
 
     /**
-     * ReadPipeScalar can indent first line.
+     * Indentation works fine.
      */
     @Test
     public void indentsValue() {


### PR DESCRIPTION
PR for #235 

The problem here was that the indented value of this scalar was folded. It's not correct to fold the value when indenting, as the resulting value will be used in printing YAML.

The string should be folded only when it is retreived via the value() method.