### PR TITLE
Refactored ReadYamlMapping

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -99,13 +99,8 @@ final class ReadYamlMapping extends BaseYamlMapping {
 
     @Override
     public YamlMapping yamlMapping(final YamlNode key) {
-        final YamlNode value;
         final YamlMapping found;
-        if(key instanceof Scalar) {
-            value = this.valueOfStringKey(((Scalar) key).value());
-        } else {
-            value = this.valueOfNodeKey(key);
-        }
+        final YamlNode value = this.value(key);
         if(value instanceof ReadYamlMapping) {
             found = (ReadYamlMapping) value;
         } else {
@@ -116,13 +111,8 @@ final class ReadYamlMapping extends BaseYamlMapping {
 
     @Override
     public YamlSequence yamlSequence(final YamlNode key) {
-        final YamlNode value;
         final YamlSequence found;
-        if(key instanceof Scalar) {
-            value = this.valueOfStringKey(((Scalar) key).value());
-        } else {
-            value = this.valueOfNodeKey(key);
-        }
+        final YamlNode value = this.value(key);
         if(value instanceof ReadYamlSequence) {
             found = (ReadYamlSequence) value;
         } else {
@@ -133,13 +123,8 @@ final class ReadYamlMapping extends BaseYamlMapping {
 
     @Override
     public String string(final YamlNode key) {
-        final YamlNode value;
         final String found;
-        if(key instanceof Scalar) {
-            value = this.valueOfStringKey(((Scalar) key).value());
-        } else {
-            value = this.valueOfNodeKey(key);
-        }
+        final YamlNode value = this.value(key);
         if(value instanceof ReadPlainScalarValue) {
             found = ((ReadPlainScalarValue) value).value();
         } else {
@@ -150,30 +135,20 @@ final class ReadYamlMapping extends BaseYamlMapping {
 
     @Override
     public String foldedBlockScalar(final YamlNode key) {
-        final YamlNode value;
-        final Scalar found;
-        if(key instanceof Scalar) {
-            value = this.valueOfStringKey(((Scalar) key).value());
-        } else {
-            value = this.valueOfNodeKey(key);
-        }
+        final String found;
+        final YamlNode value = this.value(key);
         if(value instanceof ReadFoldedBlockScalar) {
-            found = (ReadFoldedBlockScalar) value;
+            found = ((ReadFoldedBlockScalar) value).toString();
         } else {
             found = null;
         }
-        return found.value();
+        return found;
     }
 
     @Override
     public Collection<String> literalBlockScalar(final YamlNode key) {
-        final YamlNode value;
         final Collection<String> found;
-        if(key instanceof Scalar) {
-            value = this.valueOfStringKey(((Scalar) key).value());
-        } else {
-            value = this.valueOfNodeKey(key);
-        }
+        final YamlNode value = this.value(key);
         if(value instanceof ReadLiteralBlockScalar) {
             found = Arrays.asList(
                 ((ReadLiteralBlockScalar) value)

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -149,6 +149,15 @@ public interface YamlMapping extends YamlNode {
 
     /**
      * Get the YamlNode mapped to the specified key.
+     * @param key String key.
+     * @return The found YamlNode or null if nothing is found.
+     */
+    default YamlNode value(final String key) {
+        return this.value(new PlainStringScalar(key));
+    }
+
+    /**
+     * Get the YamlNode mapped to the specified key.
      * @param key YamlNode key. Could be a simple scalar,
      *  a YamlMapping or a YamlSequence.
      * @return The found YamlNode or null if nothing is found.


### PR DESCRIPTION
fixes #255 

* ``valueOfStringKey`` and ``valueOfNodeKey`` can now also search for plain scalars => they cover any kind of value;

* made method ``value(YamlNode)`` use the above 2 methods;
* simplified all other methods by making them use method ``value(YamlNode)``;
   Basically, we corrected the flow. Method ``value(...)`` actually reads a generic node and the other values are casting it. Previously, it was the exactly the other way arround.

* Added convenience method ``value(String)`` on the YamlMapping interface;