### PR TITLE
YamlMapping Holds Order Of Insetion/Reading

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -63,7 +63,7 @@ final class ReadYamlMapping extends BaseYamlMapping {
 
     @Override
     public Set<YamlNode> keys() {
-        final Set<YamlNode> keys = new TreeSet<>();
+        final Set<YamlNode> keys = new LinkedHashSet<>();
         for (final YamlLine line : this.lines) {
             final String trimmed = line.trimmed();
             if(trimmed.startsWith(":")) {

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -39,10 +39,10 @@ import java.util.*;
 final class RtYamlMapping extends BaseYamlMapping {
 
     /**
-     * Key:value tree map (ordered keys).
+     * Key:value linked map (maintains the order of insertion).
      */
     private final Map<YamlNode, YamlNode> mappings =
-        new TreeMap<YamlNode, YamlNode>();
+        new LinkedHashMap<>();
 
     /**
      * Ctor.
@@ -54,9 +54,19 @@ final class RtYamlMapping extends BaseYamlMapping {
 
     @Override
     public Set<YamlNode> keys() {
-        final Set<YamlNode> keys = new TreeSet<>();
+        final Set<YamlNode> keys = new LinkedHashSet<>();
         keys.addAll(this.mappings.keySet());
         return keys;
+    }
+
+    @Override
+    public Collection<YamlNode> values() {
+        return this.mappings.values();
+    }
+
+    @Override
+    public YamlNode value(final YamlNode key) {
+        return this.mappings.get(key);
     }
 
     @Override
@@ -127,13 +137,4 @@ final class RtYamlMapping extends BaseYamlMapping {
         return found;
     }
 
-    @Override
-    public Collection<YamlNode> values() {
-        return this.mappings.values();
-    }
-
-    @Override
-    public YamlNode value(final YamlNode key) {
-        return this.mappings.get(key);
-    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
@@ -27,7 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /**
@@ -49,7 +49,7 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
      * Default ctor.
      */
     RtYamlMappingBuilder() {
-        this(new HashMap<YamlNode, YamlNode>());
+        this(new LinkedHashMap<>());
     }
 
     /**
@@ -80,7 +80,7 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
 
     @Override
     public YamlMappingBuilder add(final YamlNode key, final YamlNode value) {
-        final Map<YamlNode, YamlNode> withAddedPair = new HashMap<>();
+        final Map<YamlNode, YamlNode> withAddedPair = new LinkedHashMap<>();
         withAddedPair.putAll(this.pairs);
         withAddedPair.put(key, value);
         return new RtYamlMappingBuilder(withAddedPair);

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -45,7 +45,6 @@ public interface YamlMapping extends YamlNode {
 
     /**
      * Return the keys' set of this mapping.<br><br>
-     * <b>Pay attention: </b> the keys are ordered.
      * @return Set of YamlNode keys.
      */
     Set<YamlNode> keys();

--- a/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
@@ -29,7 +29,7 @@ package com.amihaiemil.eoyaml;
 
 import static org.hamcrest.CoreMatchers.is;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.LinkedList;
 
 import org.hamcrest.MatcherAssert;
@@ -105,9 +105,7 @@ public final class PlainStringScalarTest {
     @Test
     public void comparesToMapping() {
         PlainStringScalar first = new PlainStringScalar("java");
-        RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
-        );
+        RtYamlMapping map = new RtYamlMapping(new LinkedHashMap<>());
         MatcherAssert.assertThat(first.compareTo(map), Matchers.lessThan(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFoldedBlockScalarTest.java
@@ -27,10 +27,8 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
+
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
@@ -54,9 +52,7 @@ public final class ReadFoldedBlockScalarTest {
         lines.add(new RtYamlLine("Third Line", 3));
         final ReadFoldedBlockScalar scalar =
             new ReadFoldedBlockScalar(new AllYamlLines(lines));
-        RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
-        );
+        RtYamlMapping map = new RtYamlMapping(new LinkedHashMap<>());
         MatcherAssert.assertThat(scalar.compareTo(map), Matchers.lessThan(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadLiteralBlockScalarTest.java
@@ -27,10 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
+import java.util.*;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -76,9 +73,7 @@ public final class ReadLiteralBlockScalarTest {
         lines.add(new RtYamlLine("Third Line.", 3));
         final ReadLiteralBlockScalar scalar =
             new ReadLiteralBlockScalar(new AllYamlLines(lines));
-        RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
-        );
+        RtYamlMapping map = new RtYamlMapping(new LinkedHashMap<>());
         MatcherAssert.assertThat(scalar.compareTo(map), Matchers.lessThan(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -73,11 +73,10 @@ public final class ReadYamlMappingTest {
     }
 
     /**
-     * ReadYamlMapping can return its keys. The keys should
-     * be ordered.
+     * ReadYamlMapping can return its keys.
      */
     @Test
-    public void returnsOrderedKeys(){
+    public void returnsKeys(){
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("zkey: somethingElse", 0));
         lines.add(new RtYamlLine("bkey: ", 1));
@@ -93,7 +92,7 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new PlainStringScalar("akey"))
+            Matchers.equalTo(new PlainStringScalar("zkey"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -101,15 +100,15 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new PlainStringScalar("zkey"))
+            Matchers.equalTo(new PlainStringScalar("akey"))
         );
     }
 
     /**
-     * ReadYamlMapping can return its key-ordered children.
+     * ReadYamlMapping can return its children.
      */
     @Test
-    public void returnsOrderedValuesOfStringKeys(){
+    public void returnsValuesOfStringKeys(){
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("zkey: somethingElse", 0));
         lines.add(new RtYamlLine("bkey: ", 1));
@@ -129,7 +128,7 @@ public final class ReadYamlMappingTest {
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
             iterator.next(),
-            Matchers.equalTo(new PlainStringScalar("something"))
+            Matchers.equalTo(new PlainStringScalar("somethingElse"))
         );
         MatcherAssert.assertThat(
             iterator.next(),
@@ -142,6 +141,10 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
+            Matchers.equalTo(new PlainStringScalar("something"))
+        );
+        MatcherAssert.assertThat(
+            iterator.next(),
             Matchers.equalTo(
                 Yaml.createYamlSequenceBuilder()
                     .add("seq")
@@ -149,18 +152,15 @@ public final class ReadYamlMappingTest {
                     .build()
             )
         );
-        MatcherAssert.assertThat(
-            iterator.next(),
-            Matchers.equalTo(new PlainStringScalar("somethingElse"))
-        );
     }
 
     /**
-     * ReadYamlMapping can return its key-ordered children.
+     * ReadYamlMapping can return its values when there are both
+     * String and YamlNode keys.
      * @checkstyle ExecutableStatementCount (100 lines)
      */
     @Test
-    public void returnsOrderedValuesOfStringAndComplexKeys(){
+    public void returnsValuesOfStringAndComplexKeys(){
         final List<YamlLine> lines = new ArrayList<>();
         lines.add(new RtYamlLine("first: somethingElse", 0));
         lines.add(new RtYamlLine("? ", 1));
@@ -189,6 +189,14 @@ public final class ReadYamlMappingTest {
         );
         MatcherAssert.assertThat(
             iterator.next(),
+            Matchers.equalTo(
+                Yaml.createYamlMappingBuilder()
+                    .add("map", "value")
+                    .build()
+            )
+        );
+        MatcherAssert.assertThat(
+            iterator.next(),
             Matchers.equalTo(new PlainStringScalar("something"))
         );
         MatcherAssert.assertThat(
@@ -202,14 +210,6 @@ public final class ReadYamlMappingTest {
         MatcherAssert.assertThat(
             iterator.next(),
             Matchers.equalTo(new PlainStringScalar("simpleValue"))
-        );
-        MatcherAssert.assertThat(
-            iterator.next(),
-            Matchers.equalTo(
-                Yaml.createYamlMappingBuilder()
-                    .add("map", "value")
-                    .build()
-            )
         );
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -48,8 +48,6 @@ public final class ReadYamlSequenceTest {
 
     /**
      * ReadYamlSequence can return the YamlMapping from a given index.
-     * Note that a YamlSequence is ordered, so the index might differ from
-     * the original found at read time.
      */
     @Test
     public void returnsYamlMappingFromIndex(){
@@ -75,8 +73,6 @@ public final class ReadYamlSequenceTest {
 
     /**
      * ReadYamlSequence can return the YamlSequence from a given index.
-     * Note that a YamlSequence is ordered, so the index might differ from
-     * the original found at read time.
      */
     @Test
     public void returnsYamlSequenceFromIndex(){
@@ -100,8 +96,6 @@ public final class ReadYamlSequenceTest {
 
     /**
      * ReadYamlSequence can return the plain scalar string from a given index.
-     * Note that a YamlSequence is ordered, so the index might differ from
-     * the original found at read time.
      */
     @Test
     public void returnsStringFromIndex(){

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -54,7 +54,6 @@ public final class RtYamlInputTest {
     @Test
     public void readsMappingWithoutComments() throws Exception {
         YamlMapping expected = Yaml.createYamlMappingBuilder()
-            .add("name", "eo-yaml")
             .add("architect", "mihai")
             .add("developers",
                 Yaml.createYamlSequenceBuilder()
@@ -62,7 +61,9 @@ public final class RtYamlInputTest {
                     .add("salikjan")
                     .add("sherif")
                     .build()
-            ).build();
+            )
+            .add("name", "eo-yaml")
+            .build();
         YamlMapping read = new RtYamlInput(
             new FileInputStream(
                 new File("src/test/resources/commentedMapping.yml")

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingTest.java
@@ -50,11 +50,11 @@ import org.mockito.Mockito;
 public final class RtYamlMappingTest {
 
     /**
-     * RtYamlMapping can fetch its key-ordered values.
+     * RtYamlMapping can fetch its values.
      */
     @Test
-    public void fetchesOrderedValues() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+    public void fetchesValues() {
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key2"), new PlainStringScalar("value1"));
         mappings.put(new PlainStringScalar("key3"), new PlainStringScalar("value2"));
         mappings.put(new PlainStringScalar("key1"), new PlainStringScalar("value3"));
@@ -66,22 +66,22 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(children.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = children.iterator();
         MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new PlainStringScalar("value3"))
-        );
-        MatcherAssert.assertThat(
             iterator.next(), Matchers.equalTo(new PlainStringScalar("value1"))
         );
         MatcherAssert.assertThat(
             iterator.next(), Matchers.equalTo(new PlainStringScalar("value2"))
         );
+        MatcherAssert.assertThat(
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("value3"))
+        );
     }
 
     /**
-     * RtYamlMapping can fetch its ordered keys.
+     * RtYamlMapping can fetch its keys.
      */
     @Test
-    public void fetchesOrderedKeys() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+    public void fetchesKeys() {
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
@@ -93,13 +93,13 @@ public final class RtYamlMappingTest {
         MatcherAssert.assertThat(keys.size(), Matchers.equalTo(3));
         final Iterator<YamlNode> iterator = keys.iterator();
         MatcherAssert.assertThat(
+            iterator.next(), Matchers.equalTo(new PlainStringScalar("key3"))
+        );
+        MatcherAssert.assertThat(
             iterator.next(), Matchers.equalTo(new PlainStringScalar("key1"))
         );
         MatcherAssert.assertThat(
             iterator.next(), Matchers.equalTo(new PlainStringScalar("key2"))
-        );
-        MatcherAssert.assertThat(
-            iterator.next(), Matchers.equalTo(new PlainStringScalar("key3"))
         );
 
     }
@@ -109,7 +109,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsYamlScalarAsString() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         String value = "value2";
         PlainStringScalar key = new PlainStringScalar("key2");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
@@ -131,7 +131,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsNullOnMissingScalar() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         PlainStringScalar key = new PlainStringScalar("missing");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key4"), Mockito.mock(YamlNode.class));
@@ -151,7 +151,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsYamlMapping() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
@@ -167,7 +167,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsNullOnMissingYamlMapping() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
@@ -185,7 +185,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsYamlSequence() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
@@ -200,7 +200,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsNullOnMissingYamlSequence() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
@@ -217,7 +217,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsFoldedBlockScalarAsString() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(
             new PlainStringScalar("key3"),
             Mockito.mock(YamlSequence.class)
@@ -248,7 +248,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsLiteralBlockScalar() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(
             new PlainStringScalar("key3"),
             Mockito.mock(YamlSequence.class)
@@ -288,7 +288,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsNullOnMissingKey() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlMapping.class));
         RtYamlMapping map = new RtYamlMapping(mappings);
@@ -312,7 +312,7 @@ public final class RtYamlMappingTest {
     @Test
     public void comparesToScalar() {
         RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
+            new LinkedHashMap<YamlNode, YamlNode>()
         );
         PlainStringScalar scalar = new PlainStringScalar("java");
         MatcherAssert.assertThat(
@@ -327,7 +327,7 @@ public final class RtYamlMappingTest {
     @Test
     public void comparesToSequence() {
         RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
+            new LinkedHashMap<YamlNode, YamlNode>()
         );
         RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
         MatcherAssert.assertThat(
@@ -341,7 +341,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void comparesToMapping() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key3"), new PlainStringScalar("value1"));
         mappings.put(new PlainStringScalar("key2"), new PlainStringScalar("value2"));
         mappings.put(new PlainStringScalar("key1"), new PlainStringScalar("value3"));
@@ -350,7 +350,7 @@ public final class RtYamlMappingTest {
         mappings.put(new PlainStringScalar("key4"), new PlainStringScalar("value4"));
         YamlMapping thirdmap = new RtYamlMapping(mappings);
 
-        Map<YamlNode, YamlNode> othermappings = new HashMap<>();
+        Map<YamlNode, YamlNode> othermappings = new LinkedHashMap<>();
         othermappings.put(
             new PlainStringScalar("architect"),
             Mockito.mock(YamlSequence.class)
@@ -389,7 +389,6 @@ public final class RtYamlMappingTest {
     @Test
     public void prettyPrintsSimpleYaml() throws Exception {
         YamlMapping yaml = Yaml.createYamlMappingBuilder()
-            .add("name", "eo-yaml")
             .add("architect", "mihai")
             .add("developers",
                 Yaml.createYamlSequenceBuilder()
@@ -397,7 +396,9 @@ public final class RtYamlMappingTest {
                     .add("salikjan")
                     .add("sherif")
                     .build()
-            ).build();
+            )
+            .add("name", "eo-yaml")
+            .build();
         String expected = this.readTestResource("simpleMapping.yml");
         MatcherAssert.assertThat(yaml.toString(), Matchers.equalTo(expected));
     }
@@ -411,15 +412,6 @@ public final class RtYamlMappingTest {
         YamlMapping yaml = Yaml.createYamlMappingBuilder()
             .add(
                 Yaml.createYamlSequenceBuilder()
-                    .add("Chicago cubs")
-                    .add("Detroit Tigers")
-                    .build(),
-                Yaml.createYamlSequenceBuilder()
-                    .add("2001-07-23")
-                    .build()
-            )
-            .add(
-                Yaml.createYamlSequenceBuilder()
                     .add("Atlanta Braves")
                     .add("New York Yankees")
                     .build(),
@@ -427,6 +419,15 @@ public final class RtYamlMappingTest {
                     .add("2001-07-02")
                     .add("2001-08-12")
                     .add("2001-08-14")
+                    .build()
+            )
+            .add(
+                Yaml.createYamlSequenceBuilder()
+                    .add("Chicago cubs")
+                    .add("Detroit Tigers")
+                    .build(),
+                Yaml.createYamlSequenceBuilder()
+                    .add("2001-07-23")
                     .build()
             )
             .build();
@@ -449,7 +450,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsScalarValue() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         PlainStringScalar value = new PlainStringScalar("value2");
         PlainStringScalar key = new PlainStringScalar("key2");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
@@ -465,7 +466,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsYamlMappingValue() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         YamlMapping value = Mockito.mock(YamlMapping.class);
         PlainStringScalar key = new PlainStringScalar("key2");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
@@ -481,7 +482,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsYamlSequenceValue() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
         PlainStringScalar key = new PlainStringScalar("key2");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));
@@ -497,7 +498,7 @@ public final class RtYamlMappingTest {
      */
     @Test
     public void returnsNullOnMissingValue() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         YamlSequence value = Mockito.mock(YamlSequence.class);
         PlainStringScalar key = new PlainStringScalar("key2");
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlSequence.class));

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
@@ -81,10 +81,10 @@ public final class RtYamlSequenceTest {
     }
 
     /**
-     * A Sequence maintains its order of reading.
+     * A Sequence maintains its order of insertion.
      */
     @Test
-    public void sequenceKeepsOrder() {
+    public void sequenceKeepsInsertionOrder() {
         List<YamlNode> nodes = new LinkedList<>();
         PlainStringScalar first = new PlainStringScalar("test");
         PlainStringScalar sec = new PlainStringScalar("mihai");
@@ -229,10 +229,8 @@ public final class RtYamlSequenceTest {
      */
     @Test
     public void comparesToMapping() {
-        RtYamlSequence seq = new RtYamlSequence(new LinkedList<YamlNode>());
-        RtYamlMapping map = new RtYamlMapping(
-            new HashMap<YamlNode, YamlNode>()
-        );
+        RtYamlSequence seq = new RtYamlSequence(new LinkedList<>());
+        RtYamlMapping map = new RtYamlMapping(new LinkedHashMap<>());
         MatcherAssert.assertThat(seq.compareTo(map), Matchers.lessThan(0));
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -28,7 +28,7 @@
 package com.amihaiemil.eoyaml;
 
 import java.util.Collection;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
@@ -50,7 +50,7 @@ public final class StrictYamlMappingTest {
      */
     @Test
     public void fetchesValues() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));
@@ -66,7 +66,7 @@ public final class StrictYamlMappingTest {
      */
     @Test
     public void fetchesKeys() {
-        Map<YamlNode, YamlNode> mappings = new HashMap<>();
+        Map<YamlNode, YamlNode> mappings = new LinkedHashMap<>();
         mappings.put(new PlainStringScalar("key1"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key2"), Mockito.mock(YamlNode.class));
         mappings.put(new PlainStringScalar("key3"), Mockito.mock(YamlNode.class));

--- a/src/test/java/com/amihaiemil/eoyaml/YamlMapDumpTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlMapDumpTest.java
@@ -27,10 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -61,7 +58,7 @@ public final class YamlMapDumpTest {
         StudentSimplePojo studentD =
             new StudentSimplePojo("Albert", "Einestien", 30, 4);
 
-        Map<Object, Object> map = new HashMap<>();
+        Map<Object, Object> map = new LinkedHashMap<>();
         map.put(studentA, studentB);
         map.put(studentC, studentD);
 
@@ -86,7 +83,7 @@ public final class YamlMapDumpTest {
             new StudentSimplePojo("John", "Doe", 25, 4);
         StudentSimplePojo studentB =
             new StudentSimplePojo("Albert", "Einestien", 30, 4);
-        Map<Object, Object> map = new HashMap<>();
+        Map<Object, Object> map = new LinkedHashMap<>();
         map.put("key1", studentA);
         map.put("key2", studentB);
 
@@ -107,7 +104,7 @@ public final class YamlMapDumpTest {
      */
     @Test
     public void representsMapOfStringsAndInteers() {
-        Map<Object, Object> map = new HashMap<>();
+        Map<Object, Object> map = new LinkedHashMap<>();
         map.put("key1", 12);
         map.put("key2", 13);
 

--- a/src/test/java/com/amihaiemil/eoyaml/YamlObjectDumpTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlObjectDumpTest.java
@@ -27,7 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 import org.hamcrest.MatcherAssert;
@@ -89,7 +89,7 @@ public final class YamlObjectDumpTest {
         private String lastName;
         private int age;
         private double gpa;
-        private Map<String, Integer> grades = new HashMap<>();
+        private Map<String, Integer> grades = new LinkedHashMap<>();
 
         public StudentSimplePojo(
             String firstName, String lastName, int age, double gpa


### PR DESCRIPTION
fixes #239 
Removed the ordering from YamlMappings. The pairs in the map are reflecting their insertion or reading order.
