### PR TITLE
#219 fixed YamlLines.line(...)

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
@@ -76,12 +76,10 @@ interface YamlLines extends Iterable<YamlLine> {
      */
     default YamlLine line(final int number) {
         final Collection<YamlLine> lines = this.lines();
-        int index = 0;
         for(final YamlLine line : lines){
-            if(index == number) {
+            if(line.number() == number) {
                 return line;
             }
-            index++;
         }
         throw new IllegalArgumentException(
             "Couldn't find line " + number

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**
@@ -412,7 +411,6 @@ public final class RtYamlInputTest {
      *  YamlLines.line(...) is not aware of these possible numbering diffs.
      */
     @Test
-    @Ignore
     public void readsStreamWithoutFirstStartMarkerAndComments()
         throws Exception {
         final YamlInput input = Yaml.createYamlInput(

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -405,10 +405,6 @@ public final class RtYamlInputTest {
      * A stream of YAML Documents, when the first Start Marker is missing,
      * can be read. The file also contains comments.
      * @throws Exception If something goes wrong.
-     * @todo #211:30min Fix this unit test. The YAML from the file is not
-     *  read properly, most likely because of line-numbering Issues. The first
-     *  actual line of YAML has number 3 because the comments are omitted.
-     *  YamlLines.line(...) is not aware of these possible numbering diffs.
      */
     @Test
     public void readsStreamWithoutFirstStartMarkerAndComments()


### PR DESCRIPTION
PR for #219 

* fixed bug in YamlLines.line(int) -- it was matching the index of the line with the provided number, but this was incorrect. It should match the internal number of the line, not its index in the collection.