### PR TITLE
YamlSequence: Implemented Building With Comments

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
@@ -27,10 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 
 /**
@@ -51,7 +48,7 @@ public abstract class BaseYamlMapping
     extends BaseYamlNode implements YamlMapping {
 
     /**
-     * Comments on top of the key:value pairs.
+     * Comments referring the key:value pairs.
      */
     private List<Comment> keyComments;
 
@@ -59,12 +56,12 @@ public abstract class BaseYamlMapping
      * Default ctor.
      */
     public BaseYamlMapping() {
-        this(new ArrayList<>());
+        this(new LinkedList<>());
     }
 
     /**
      * Constructor.
-     * @param keyComments Comment on top of the key: value entries.
+     * @param keyComments Comment referring to the key: value entries.
      */
     public BaseYamlMapping(final List<Comment> keyComments) {
         this.keyComments = keyComments;

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlMapping.java
@@ -156,10 +156,7 @@ public abstract class BaseYamlMapping
         return result;
     }
 
-    /**
-     * Return the comments on top of the key:value pairs.
-     * @return List of Comment.
-     */
+    @Override
     public final List<Comment> keyComments() {
         final List<Comment> comments = new ArrayList<>();
         comments.addAll(this.keyComments);

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
@@ -27,8 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
-import java.util.Iterator;
+import java.util.*;
 
 /**
  * Base YamlSequence which all implementations should extend.
@@ -46,6 +45,27 @@ import java.util.Iterator;
  */
 public abstract class BaseYamlSequence
     extends BaseYamlNode implements YamlSequence {
+
+    /**
+     * Comments referring the elements of this YamlSequence.
+     */
+    private List<Comment> comments;
+
+    /**
+     * Default ctor.
+     */
+    public BaseYamlSequence() {
+        this(new LinkedList<>());
+    }
+
+    /**
+     * Constructor.
+     * @param comments Comments referring to the elements of the sequence.
+     */
+    public BaseYamlSequence(final List<Comment> comments) {
+        this.comments = comments;
+    }
+
 
     @Override
     public final int hashCode() {
@@ -121,6 +141,16 @@ public abstract class BaseYamlSequence
             }
         }
         return result;
+    }
+
+    /**
+     * Return the comments referring to the elements in this sequence.
+     * @return List of Comment.
+     */
+    public final List<Comment> comments() {
+        final List<Comment> all = new ArrayList<>();
+        all.addAll(this.comments);
+        return all;
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
@@ -176,10 +176,12 @@ public abstract class BaseYamlSequence
             alignment.append(" ");
             spaces--;
         }
+        this.printPossibleComment(this.comment(), print, alignment.toString());
         for (final YamlNode node : this.values()) {
+            this.printPossibleElementComment(node, print, alignment.toString());
             print
                 .append(alignment)
-                .append("- ");
+                .append("-");
             if (node instanceof Scalar) {
                 this.printScalar((Scalar) node, print, indentation);
             } else  {
@@ -194,6 +196,52 @@ public abstract class BaseYamlSequence
             printed = printed.substring(0, printed.length() - 1);
         }
         return printed;
+    }
+
+    /**
+     * Add the comment referring to the sequence element, if any,
+     * to the print.
+     * @param key Key in the YamlMapping.
+     * @param print Print.
+     * @param alignment Alignment
+     */
+    private void printPossibleElementComment(
+        final YamlNode key,
+        final StringBuilder print,
+        final String alignment
+    ) {
+        for(final Comment comment : this.comments) {
+            if(key.equals(comment.yamlNode())) {
+                this.printPossibleComment(comment, print, alignment);
+                break;
+            }
+        }
+    }
+
+    /**
+     * Print a comment. Make sure to split the lines if there are more
+     * lines separated by NewLine and also add a '# ' in front of each
+     * line.
+     * @param comment Comment.
+     * @param print Printer StringBuilder.
+     * @param alignment Indentation.
+     */
+    private void printPossibleComment(
+        final Comment comment,
+        final StringBuilder print,
+        final String alignment
+    ) {
+        final String com = comment.value();
+        if(com.trim().length()!=0) {
+            String[] lines = com.split(System.lineSeparator());
+            for(final String line : lines) {
+                print
+                    .append(alignment)
+                    .append("# ")
+                    .append(line)
+                    .append(System.lineSeparator());
+            }
+        }
     }
 
     /**
@@ -215,12 +263,15 @@ public abstract class BaseYamlSequence
         if (indentable instanceof PlainStringScalar
             || indentable instanceof ReadPlainScalar
         ) {
-            print.append(indentable.indent(0)).append(System.lineSeparator());
+            print
+                .append(" ")
+                .append(indentable.indent(0))
+                .append(System.lineSeparator());
         } else if (indentable instanceof RtYamlScalarBuilder.BuiltFoldedBlockScalar
             || indentable instanceof ReadFoldedBlockScalar
         ) {
             print
-                .append(">")
+                .append(" >")
                 .append(System.lineSeparator())
                 .append(
                     indentable.indent(indentation + 2)
@@ -229,7 +280,7 @@ public abstract class BaseYamlSequence
             || indentable instanceof ReadLiteralBlockScalar
         ) {
             print
-                .append("|")
+                .append(" |")
                 .append(System.lineSeparator())
                 .append(
                     indentable.indent(indentation + 2)

--- a/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BaseYamlSequence.java
@@ -143,10 +143,7 @@ public abstract class BaseYamlSequence
         return result;
     }
 
-    /**
-     * Return the comments referring to the elements in this sequence.
-     * @return List of Comment.
-     */
+    @Override
     public final List<Comment> comments() {
         final List<Comment> all = new ArrayList<>();
         all.addAll(this.comments);

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -164,4 +164,16 @@ final class ReadYamlSequence extends BaseYamlSequence {
         return this.values().iterator();
     }
 
+    /**
+     * Return the comment referring to this YamlSequence.
+     * @todo #276:30min Continue implementing support for Comments into the
+     *  read version of YamlMapping. Comments for the elements of a sequence
+     *  are already implemented in BaseYamlSequence.
+     * @return Comment.
+     */
+    @Override
+    public Comment comment() {
+        return new BuiltComment(this, "");
+    }
+
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -39,7 +39,7 @@ import java.util.*;
 final class RtYamlMapping extends BaseYamlMapping {
 
     /**
-     * Comments on top of this mapping.
+     * Comments referring to this mapping.
      */
     private Comment comment;
 

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMappingBuilder.java
@@ -48,7 +48,7 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
     private final Map<YamlNode, YamlNode> pairs;
 
     /**
-     * Comments on top of the key:value pairs.
+     * Comments referring to the key:value pairs.
      */
     private final List<Comment> comments;
 
@@ -62,7 +62,7 @@ final class RtYamlMappingBuilder implements YamlMappingBuilder {
     /**
      * Constructor.
      * @param pairs Pairs used in building the YamlMapping.
-     * @param comments Comments on top of the key:value pairs.
+     * @param comments Comments referring to the key:value pairs.
      */
     RtYamlMappingBuilder(
         final Map<YamlNode, YamlNode> pairs,

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
@@ -39,6 +39,11 @@ import java.util.*;
 final class RtYamlSequence extends BaseYamlSequence {
 
     /**
+     * Comments referring to this sequence.
+     */
+    private Comment comment;
+
+    /**
      * Nodes in this sequence.
      */
     private final List<YamlNode> nodes = new LinkedList<>();
@@ -48,7 +53,23 @@ final class RtYamlSequence extends BaseYamlSequence {
      * @param elements Elements of this sequence.
      */
     RtYamlSequence(final Collection<YamlNode> elements) {
+        this(elements, new ArrayList<>(), "");
+    }
+
+    /**
+     * Constructor.
+     * @param elements Elements of this sequence.
+     * @param comments Comments referring to the elements of this sequence.
+     * @param comment Comment referring to this sequence itself.
+     */
+    RtYamlSequence(
+        final Collection<YamlNode> elements,
+        final List<Comment> comments,
+        final String comment
+    ) {
+        super(comments);
         this.nodes.addAll(elements);
+        this.comment = new BuiltComment(this, comment);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequence.java
@@ -154,4 +154,9 @@ final class RtYamlSequence extends BaseYamlSequence {
         return this.nodes.iterator();
     }
 
+    @Override
+    public Comment comment() {
+        return this.comment;
+    }
+
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -44,30 +44,45 @@ final class RtYamlSequenceBuilder implements YamlSequenceBuilder {
     private final List<YamlNode> nodes;
 
     /**
+     * Comments referring to the elements of the YamlSequence.
+     */
+    private final List<Comment> comments;
+
+    /**
      * Default ctor.
      */
     RtYamlSequenceBuilder() {
-        this(new LinkedList<YamlNode>());
+        this(new LinkedList<>(), new LinkedList<>());
     }
 
     /**
      * Constructor.
      * @param nodes Nodes used in building the YamlSequence
+     * @param comments Comments referring to the elements of the YamlSequence.
      */
-    RtYamlSequenceBuilder(final List<YamlNode> nodes) {
+    RtYamlSequenceBuilder(
+        final List<YamlNode> nodes,
+        final List<Comment> comments
+    ) {
         this.nodes = nodes;
-    }
-    
-    @Override
-    public YamlSequenceBuilder add(final YamlNode node) {
-        final List<YamlNode> list = new LinkedList<>();
-        list.addAll(this.nodes);
-        list.add(node);
-        return new RtYamlSequenceBuilder(list);
+        this.comments = comments;
     }
 
     @Override
-    public YamlSequence build() {
+    public YamlSequenceBuilder add(final YamlNode node, final String comment) {
+        final List<YamlNode> elements = new LinkedList<>();
+        elements.addAll(this.nodes);
+        elements.add(node);
+
+        final List<Comment> withComments = new LinkedList<>();
+        withComments.addAll(this.comments);
+        withComments.add(new BuiltComment(node, comment));
+
+        return new RtYamlSequenceBuilder(elements, withComments);
+    }
+
+    @Override
+    public YamlSequence build(final String comment) {
         return new RtYamlSequence(this.nodes);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -57,12 +57,7 @@ final class RtYamlSequenceBuilder implements YamlSequenceBuilder {
     RtYamlSequenceBuilder(final List<YamlNode> nodes) {
         this.nodes = nodes;
     }
-
-    @Override
-    public YamlSequenceBuilder add(final String value) {
-        return this.add(new PlainStringScalar(value));
-    }
-
+    
     @Override
     public YamlSequenceBuilder add(final YamlNode node) {
         final List<YamlNode> list = new LinkedList<>();

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilder.java
@@ -83,6 +83,6 @@ final class RtYamlSequenceBuilder implements YamlSequenceBuilder {
 
     @Override
     public YamlSequence build(final String comment) {
-        return new RtYamlSequence(this.nodes);
+        return new RtYamlSequence(this.nodes, this.comments, comment);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlSequence.java
@@ -152,4 +152,9 @@ public final class StrictYamlSequence extends BaseYamlSequence {
     public Iterator<YamlNode> iterator() {
         return this.decorated.iterator();
     }
+
+    @Override
+    public Comment comment() {
+        return this.decorated.comment();
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -397,7 +397,8 @@ public interface YamlMapping extends YamlNode {
     /**
      * Comments referring to the key:value pairs of this
      * mapping.
-     * @return List of Comment.
+     * @return List of Comment which is empty if there are
+     *  no comments.
      */
     List<Comment> keyComments();
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
@@ -32,6 +32,7 @@ import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
 import java.util.Iterator;
+import java.util.List;
 
 /**
  * A Yaml sequence.
@@ -96,6 +97,13 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
      * @return Iterator of YamlNode.
      */
     Iterator<YamlNode> iterator();
+
+    /**
+     * Comments referring to the elements of this sequence.
+     * @return List of Comment which is empty if there are
+     *  no comments.
+     */
+    List<Comment> comments();
 
     /**
      * Convenience method to directly read an integer value

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
@@ -99,6 +99,12 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
     Iterator<YamlNode> iterator();
 
     /**
+     * Comment referring to this YamlSequence.
+     * @return Comment.
+     */
+    Comment comment();
+
+    /**
      * Comments referring to the elements of this sequence.
      * @return List of Comment which is empty if there are
      *  no comments.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequenceBuilder.java
@@ -34,14 +34,26 @@ package com.amihaiemil.eoyaml;
  * @since 1.0.0
  */
 public interface YamlSequenceBuilder {
+
     /**
      * Add a value to the sequence.
      * @param value String
      * @return This builder
      */
     default YamlSequenceBuilder add(final String value) {
+        return this.add(value, "");
+    }
+
+    /**
+     * Add a value to the sequence.
+     * @param value String
+     * @param comment Comment referring to the added value.
+     * @return This builder
+     */
+    default YamlSequenceBuilder add(final String value, final String comment) {
         return this.add(
-            Yaml.createYamlScalarBuilder().addLine(value).buildPlainScalar()
+            Yaml.createYamlScalarBuilder().addLine(value).buildPlainScalar(),
+            comment
         );
     }
 
@@ -50,11 +62,30 @@ public interface YamlSequenceBuilder {
      * @param node YamlNode
      * @return This builder
      */
-    YamlSequenceBuilder add(final YamlNode node);
+    default YamlSequenceBuilder add(final YamlNode node) {
+        return this.add(node, "");
+    }
+
+    /**
+     * Add a value to the sequence.
+     * @param node YamlNode
+     * @param comment Comment referring to the added YamlNode.
+     * @return This builder
+     */
+    YamlSequenceBuilder add(final YamlNode node, final String comment);
 
     /**
      * Build the YamlSequence.
      * @return Built YamlSequence
      */
-    YamlSequence build();
+    default YamlSequence build() {
+        return this.build("");
+    }
+
+    /**
+     * Build the YamlSequence and specify a comment referring to it.
+     * @param comment Comment about the built YamlSequence.
+     * @return Built YamlSequence
+     */
+    YamlSequence build(final String comment);
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequenceBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequenceBuilder.java
@@ -39,7 +39,11 @@ public interface YamlSequenceBuilder {
      * @param value String
      * @return This builder
      */
-    YamlSequenceBuilder add(final String value);
+    default YamlSequenceBuilder add(final String value) {
+        return this.add(
+            Yaml.createYamlScalarBuilder().addLine(value).buildPlainScalar()
+        );
+    }
 
     /**
      * Add a value to the sequence.

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlSequence.java
@@ -164,6 +164,11 @@ public final class MergedYamlSequence extends BaseYamlSequence {
         return this.merged.iterator();
     }
 
+    @Override
+    public Comment comment() {
+        return this.merged.comment();
+    }
+
     /**
      * Merge the two sequences.
      * @checkstyle CyclomaticComplexity (100 lines)

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlMappingBuilderTest.java
@@ -122,4 +122,22 @@ public final class RtYamlMappingBuilderTest {
             Matchers.equalTo(2)
         );
     }
+
+    /**
+     * RtYamlMappingBuilder can build a YamlMapping with a comment
+     * referring to it.
+     */
+    @Test
+    public void buildsYamlMappingWithComment() {
+        final YamlMapping mapping = new RtYamlMappingBuilder()
+            .add("key", "value")
+            .add("key1", "value1")
+            .build("some test mapping");
+        final Comment com = mapping.comment();
+        MatcherAssert.assertThat(com.yamlNode(), Matchers.is(mapping));
+        MatcherAssert.assertThat(
+            com.value(),
+            Matchers.equalTo("some test mapping")
+        );
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceBuilderTest.java
@@ -92,4 +92,21 @@ public final class RtYamlSequenceBuilderTest {
             Matchers.equalTo(2)
         );
     }
+    /**
+     * RtYamlSequenceBuilder can build a YamlSequence with a comment
+     * referring to it.
+     */
+    @Test
+    public void buildsYamlMappingWithComment() {
+        final YamlSequence seq = new RtYamlSequenceBuilder()
+            .add("element 1")
+            .add("element 2")
+            .build("some test sequence");
+        final Comment com = seq.comment();
+        MatcherAssert.assertThat(com.yamlNode(), Matchers.is(seq));
+        MatcherAssert.assertThat(
+            com.value(),
+            Matchers.equalTo("some test sequence")
+        );
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/SkipTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/SkipTest.java
@@ -39,7 +39,7 @@ import java.util.List;
  * Unit tests for {@link Skip}.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 4.0.2
+ * @since 4.2.0
  */
 public final class SkipTest {
 

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -243,4 +243,18 @@ public final class StrictYamlMappingTest {
             strict.value(key), Matchers.equalTo(value)
         );
     }
+
+    /**
+     * StrictYamlMapping can return the Comment.
+     */
+    @Test
+    public void returnsComment() {
+        final Comment com = Mockito.mock(Comment.class);
+        final YamlMapping original = Mockito.mock(YamlMapping.class);
+        Mockito.when(original.comment()).thenReturn(com);
+        MatcherAssert.assertThat(
+            new StrictYamlMapping(original).comment(),
+            Matchers.is(com)
+        );
+    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlSequenceTest.java
@@ -227,4 +227,18 @@ public final class StrictYamlSequenceTest {
         );
     }
 
+    /**
+     * StrictYamlSequence can return the Comment.
+     */
+    @Test
+    public void returnsComment() {
+        final Comment com = Mockito.mock(Comment.class);
+        final YamlSequence original = Mockito.mock(YamlSequence.class);
+        Mockito.when(original.comment()).thenReturn(com);
+        MatcherAssert.assertThat(
+            new StrictYamlSequence(original).comment(),
+            Matchers.is(com)
+        );
+    }
+
 }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlSequenceCommentsPrintTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlSequenceCommentsPrintTest.java
@@ -1,0 +1,96 @@
+/**
+ * Copyright (c) 2016-2020, Mihai Emil Andronache
+ * All rights reserved.
+ *
+ * Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ * Redistributions of source code must retain the above copyright notice, this
+ *  list of conditions and the following disclaimer.
+ *  Redistributions in binary form must reproduce the above copyright notice,
+ *  this list of conditions and the following disclaimer in the documentation
+ *  and/or other materials provided with the distribution.
+ * Neither the name of the copyright holder nor the names of its
+ *  contributors may be used to endorse or promote products derived from
+ *  this software without specific prior written permission.
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+ * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+ * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+ * ARE
+ * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+ * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+ * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+ * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+ * LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+ * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+ * SUCH DAMAGE.
+ */
+package com.amihaiemil.eoyaml;
+
+import org.apache.commons.io.IOUtils;
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.IOException;
+
+/**
+ * Test cases for printing a YamlSequence together with its
+ * added or read comments.
+ * @author Mihai Andronache (amihaiemil@gmail.com)
+ * @version $Id$
+ * @since 4.2.0
+ */
+public final class YamlSequenceCommentsPrintTest {
+
+    /**
+     * A built YamlSequence with added comments is being
+     * printed properly.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void printsBuiltYamlSequenceWithComments() throws Exception {
+        final YamlSequence commented = Yaml.createYamlSequenceBuilder()
+            .add("element1")
+            .add("element2", "a plain scalar string in a sequence")
+            .add("element3")
+            .add(
+                Yaml.createYamlMappingBuilder()
+                    .add("key", "value")
+                    .add("key2", "value2")
+                    .build(),
+                "a mapping as an element of a sequence"
+            )
+            .build("a sequence with comments");
+        System.out.println(commented);
+        MatcherAssert.assertThat(
+            commented.toString(),
+            Matchers.equalTo(
+                this.readExpected("commentedSequence.yml")
+            )
+        );
+    }
+
+    /**
+     * Read a test resource file's contents.
+     * @param fileName File to read.
+     * @return File's contents as String.
+     * @throws FileNotFoundException If something is wrong.
+     * @throws IOException If something is wrong.
+     */
+    private String readExpected(final String fileName)
+        throws FileNotFoundException, IOException {
+        return new String(
+            IOUtils.toByteArray(
+                new FileInputStream(
+                    new File(
+                        "src/test/resources/" + fileName
+                    )
+                )
+            )
+        );
+    }
+}

--- a/src/test/resources/commentedSequence.yml
+++ b/src/test/resources/commentedSequence.yml
@@ -1,0 +1,9 @@
+# a sequence with comments
+- element1
+# a plain scalar string in a sequence
+- element2
+- element3
+# a mapping as an element of a sequence
+-
+  key: value
+  key2: value2

--- a/src/test/resources/complexSequence.yml
+++ b/src/test/resources/complexSequence.yml
@@ -1,10 +1,10 @@
 - amihaiemil
 - salikjan
-- 
+-
   - element1
   - element2
   - element3
-- 
+-
   rule1: test
   rule2: test2
   rule3: test3

--- a/src/test/resources/printing_tests/yamlSequenceAllNodes.txt
+++ b/src/test/resources/printing_tests/yamlSequenceAllNodes.txt
@@ -7,9 +7,9 @@
   a scalar folded
   on more lines
   for readability
-- 
+-
   key: value
-- 
+-
   - a sequence
   - of plain scalars
   - as child


### PR DESCRIPTION
fixes #276 
* Comments can be specified for each element of the sequence and for the sequence itself when building
* ``YamlSequence.comment()`` returns the comment of the sequence itself
* ``YamlSequence.comments()`` returns the comments referring to the elements of the sequence
* Implemented printing of the comments
* Unit tests for printing + small bugfix regarding trailing spaces.
* Left puzzle to continue implementation for the reading part.