### PR TITLE
#134 read the null Scalar + tests

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
@@ -59,6 +59,13 @@ final class ReadPlainScalar extends BaseScalar {
         this.scalar = scalar;
     }
 
+    /**
+     * Unescaped String value of this scalar. Pay attention, if the
+     * scalar's value is the "null" String, then we return null, because
+     * "null" is a reserved keyword in YAML, indicating a null Scalar.
+     * @checkstyle ReturnCount (50 lines)
+     * @return String or null if the Strings value is "null".
+     */
     @Override
     public String value() {
         final String value;
@@ -70,7 +77,11 @@ final class ReadPlainScalar extends BaseScalar {
         } else {
             value = trimmed;
         }
-        return this.unescape(value);
+        if("null".equals(value)) {
+            return null;
+        } else {
+            return this.unescape(value);
+        }
     }
 
     @Override

--- a/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadPlainScalarTest.java
@@ -55,6 +55,31 @@ public final class ReadPlainScalarTest {
     }
 
     /**
+     * ReadPlainScalar can return the scalar's null value from a mapping line.
+     */
+    @Test
+    public void returnsNullValueFromMappingLine() {
+        final Scalar scalar = new ReadPlainScalar(
+            new AllYamlLines(new ArrayList<>()),
+            new RtYamlLine("key: null", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.nullValue());
+    }
+
+    /**
+     * ReadPlainScalar can return the "null" String value from a mapping line,
+     * because it is escaped.
+     */
+    @Test
+    public void returnsEscapedNullStringFromMappingLine() {
+        final Scalar scalar = new ReadPlainScalar(
+            new AllYamlLines(new ArrayList<>()),
+            new RtYamlLine("key: 'null'", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("null"));
+    }
+
+    /**
      * ReadPlainScalar can return the scalar's value from a sequence line.
      */
     @Test
@@ -64,6 +89,31 @@ public final class ReadPlainScalarTest {
             new RtYamlLine("- value", 0)
         );
         MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
+    }
+
+    /**
+     * ReadPlainScalar can return the scalar's null value from a sequence line.
+     */
+    @Test
+    public void returnsNullValueFromSequenceLine() {
+        final Scalar scalar = new ReadPlainScalar(
+            new AllYamlLines(new ArrayList<>()),
+            new RtYamlLine("- null", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.nullValue());
+    }
+
+    /**
+     * ReadPlainScalar can return the "null" String, because
+     * it is escaped.
+     */
+    @Test
+    public void returnsEscapedNullStringFromSequenceLine() {
+        final Scalar scalar = new ReadPlainScalar(
+            new AllYamlLines(new ArrayList<>()),
+            new RtYamlLine("- \"null\"", 0)
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("null"));
     }
 
     /**
@@ -119,6 +169,33 @@ public final class ReadPlainScalarTest {
             line
         );
         MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("value"));
+    }
+
+    /**
+     * ReadPlainScalar will return the null scalar.
+     */
+    @Test
+    public void returnsNullScalar() {
+        final YamlLine line = new RtYamlLine("null", 0);
+        final Scalar scalar = new ReadPlainScalar(
+                new AllYamlLines(new ArrayList<>()),
+                line
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.nullValue());
+    }
+
+    /**
+     * ReadPlainScalar will return the "null" String scalar, not null,
+     * because it is escaped.
+     */
+    @Test
+    public void returnsEscapedNullScalar() {
+        final YamlLine line = new RtYamlLine("'null'", 0);
+        final Scalar scalar = new ReadPlainScalar(
+            new AllYamlLines(new ArrayList<>()),
+            line
+        );
+        MatcherAssert.assertThat(scalar.value(), Matchers.equalTo("null"));
     }
 
     /**


### PR DESCRIPTION
Fixes #134 
Final step:
* read the ``null`` YAML keyword as a Scalar with ``null`` value.
* added unit tests