### PR TITLE
YamlMapping new Default Methods

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -173,18 +173,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String string(final YamlNode key) {
-        final String found;
-        final YamlNode value = this.value(key);
-        if(value instanceof ReadPlainScalar) {
-            found = ((ReadPlainScalar) value).value();
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public String foldedBlockScalar(final YamlNode key) {
         final String found;
         final YamlNode value = this.value(key);

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -173,18 +173,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlMapping yamlMapping(final YamlNode key) {
-        final YamlMapping found;
-        final YamlNode value = this.value(key);
-        if(value instanceof ReadYamlMapping) {
-            found = (ReadYamlMapping) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public YamlSequence yamlSequence(final YamlNode key) {
         final YamlSequence found;
         final YamlNode value = this.value(key);

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -172,22 +172,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
         );
     }
 
-    @Override
-    public Collection<String> literalBlockScalar(final YamlNode key) {
-        final Collection<String> found;
-        final YamlNode value = this.value(key);
-        if(value instanceof ReadLiteralBlockScalar) {
-            found = Arrays.asList(
-                ((ReadLiteralBlockScalar) value)
-                    .value()
-                    .split(System.lineSeparator())
-            );
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
     /**
      * The YamlNode value associated with a String (scalar) key.
      * @param key String key.

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -173,18 +173,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlSequence yamlSequence(final YamlNode key) {
-        final YamlSequence found;
-        final YamlNode value = this.value(key);
-        if(value instanceof ReadYamlSequence) {
-            found = (ReadYamlSequence) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public String string(final YamlNode key) {
         final String found;
         final YamlNode value = this.value(key);

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -130,15 +130,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public Collection<YamlNode> values() {
-        final List<YamlNode> values = new LinkedList<>();
-        for(final YamlNode key : this.keys()) {
-            values.add(this.value(key));
-        }
-        return values;
-    }
-
-    @Override
     public YamlNode value(final YamlNode key) {
         final YamlNode value;
         if(key instanceof Scalar) {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -173,18 +173,6 @@ final class ReadYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String foldedBlockScalar(final YamlNode key) {
-        final String found;
-        final YamlNode value = this.value(key);
-        if(value instanceof ReadFoldedBlockScalar) {
-            found = ((ReadFoldedBlockScalar) value).toString();
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public Collection<String> literalBlockScalar(final YamlNode key) {
         final Collection<String> found;
         final YamlNode value = this.value(key);

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -88,18 +88,6 @@ final class RtYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlSequence yamlSequence(final YamlNode key) {
-        final YamlNode value = this.mappings.get(key);
-        final YamlSequence found;
-        if (value != null && value instanceof YamlSequence) {
-            found =  (YamlSequence) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public String string(final YamlNode key) {
         final YamlNode value = this.mappings.get(key);
         final String found;

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -88,18 +88,6 @@ final class RtYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String string(final YamlNode key) {
-        final YamlNode value = this.mappings.get(key);
-        final String found;
-        if (value != null && value instanceof PlainStringScalar) {
-            found = ((Scalar) value).value();
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public String foldedBlockScalar(final YamlNode key) {
         final YamlNode value = this.mappings.get(key);
         final String found;

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -88,18 +88,6 @@ final class RtYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlMapping yamlMapping(final YamlNode key) {
-        final YamlNode value = this.mappings.get(key);
-        final YamlMapping found;
-        if (value != null && value instanceof YamlMapping) {
-            found = (YamlMapping) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    @Override
     public YamlSequence yamlSequence(final YamlNode key) {
         final YamlNode value = this.mappings.get(key);
         final YamlSequence found;

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -87,23 +87,4 @@ final class RtYamlMapping extends BaseYamlMapping {
         return this.comment;
     }
 
-
-    @Override
-    public Collection<String> literalBlockScalar(final YamlNode key) {
-        final YamlNode value = this.mappings.get(key);
-        final Collection<String> found;
-        if (value != null
-            && value instanceof RtYamlScalarBuilder.BuiltLiteralBlockScalar
-        ) {
-            found = Arrays.asList(
-                ((RtYamlScalarBuilder.BuiltLiteralBlockScalar) value)
-                    .value()
-                    .split(System.lineSeparator())
-            );
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -78,11 +78,6 @@ final class RtYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public Collection<YamlNode> values() {
-        return this.mappings.values();
-    }
-
-    @Override
     public YamlNode value(final YamlNode key) {
         return this.mappings.get(key);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlMapping.java
@@ -87,19 +87,6 @@ final class RtYamlMapping extends BaseYamlMapping {
         return this.comment;
     }
 
-    @Override
-    public String foldedBlockScalar(final YamlNode key) {
-        final YamlNode value = this.mappings.get(key);
-        final String found;
-        if (value != null
-            && value instanceof RtYamlScalarBuilder.BuiltFoldedBlockScalar
-        ) {
-            found = ((Scalar) value).value();
-        } else {
-            found = null;
-        }
-        return found;
-    }
 
     @Override
     public Collection<String> literalBlockScalar(final YamlNode key) {

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -66,17 +66,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlSequence yamlSequence(final YamlNode key) {
-        YamlSequence found = this.decorated.yamlSequence(key);
-        if (found == null) {
-            throw new YamlNodeNotFoundException(
-                "No YamlSequence found for key " + key
-            );
-        }
-        return found;
-    }
-
-    @Override
     public String string(final YamlNode key) {
         String found = this.decorated.string(key);
         if (found == null) {

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -66,17 +66,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String foldedBlockScalar(final YamlNode key) {
-        final String found = this.decorated.foldedBlockScalar(key);
-        if (found == null) {
-            throw new YamlNodeNotFoundException(
-                "No Folded Block Scalar found for key " + key
-            );
-        }
-        return found;
-    }
-
-    @Override
     public Collection<String> literalBlockScalar(final YamlNode key) {
         final Collection<String> found = this.decorated.literalBlockScalar(
             key

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -66,17 +66,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlMapping yamlMapping(final YamlNode key) {
-        YamlMapping found = this.decorated.yamlMapping(key);
-        if (found == null) {
-            throw new YamlNodeNotFoundException(
-                "No YamlMapping found for key " + key
-            );
-        }
-        return found;
-    }
-
-    @Override
     public YamlSequence yamlSequence(final YamlNode key) {
         YamlSequence found = this.decorated.yamlSequence(key);
         if (found == null) {
@@ -127,7 +116,7 @@ public final class StrictYamlMapping extends BaseYamlMapping {
         YamlNode found = this.decorated.value(key);
         if (found == null) {
             throw new YamlNodeNotFoundException(
-                "No String found for key " + key
+                "No YAML found for key " + key
             );
         }
         return found;

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -66,11 +66,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public Collection<YamlNode> values() {
-        return this.decorated.values();
-    }
-
-    @Override
     public YamlMapping yamlMapping(final YamlNode key) {
         YamlMapping found = this.decorated.yamlMapping(key);
         if (found == null) {

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -27,7 +27,6 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Collection;
 import java.util.Set;
 
 /**
@@ -63,19 +62,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     @Override
     public Set<YamlNode> keys() {
         return this.decorated.keys();
-    }
-
-    @Override
-    public Collection<String> literalBlockScalar(final YamlNode key) {
-        final Collection<String> found = this.decorated.literalBlockScalar(
-            key
-        );
-        if (found == null) {
-            throw new YamlNodeNotFoundException(
-                "No Literal Block Scalar found for key " + key
-            );
-        }
-        return found;
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StrictYamlMapping.java
@@ -66,17 +66,6 @@ public final class StrictYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String string(final YamlNode key) {
-        String found = this.decorated.string(key);
-        if (found == null) {
-            throw new YamlNodeNotFoundException(
-                "No String found for key " + key
-            );
-        }
-        return found;
-    }
-
-    @Override
     public String foldedBlockScalar(final YamlNode key) {
         final String found = this.decorated.foldedBlockScalar(key);
         if (found == null) {

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -146,8 +146,16 @@ public interface YamlMapping extends YamlNode {
      * @return String or null if the key is missing, or not pointing
      *  to a scalar.
      */
-    String string(final YamlNode key);
-
+    default String string(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        final String found;
+        if (value != null && value instanceof Scalar) {
+            found = ((Scalar) value).value();
+        } else {
+            found = null;
+        }
+        return found;
+    }
     /**
      * Get the String folded block scalar associated with the given key.
      * @param key String key

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -117,7 +117,16 @@ public interface YamlMapping extends YamlNode {
      * @return Yaml sequence or null if the key is missing, or not pointing
      *  to a sequence
      */
-    YamlSequence yamlSequence(final YamlNode key);
+    default YamlSequence yamlSequence(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        final YamlSequence found;
+        if (value != null && value instanceof YamlSequence) {
+            found =  (YamlSequence) value;
+        } else {
+            found = null;
+        }
+        return found;
+    }
 
     /**
      * Get the String associated with the given key.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -88,7 +88,16 @@ public interface YamlMapping extends YamlNode {
      * @return Yaml mapping or null if the key is missing, or not pointing
      *  to a mapping.
      */
-    YamlMapping yamlMapping(final YamlNode key);
+    default YamlMapping yamlMapping(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        final YamlMapping found;
+        if (value != null && value instanceof YamlMapping) {
+            found = (YamlMapping) value;
+        } else {
+            found = null;
+        }
+        return found;
+    }
 
     /**
      * Get the Yaml sequence associated with the given key.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -31,6 +31,8 @@ import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
 import java.util.Collection;
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Set;
 
 /**
@@ -50,11 +52,24 @@ public interface YamlMapping extends YamlNode {
     Set<YamlNode> keys();
 
     /**
+     * Get the YamlNode mapped to the specified key.
+     * @param key YamlNode key. Could be a simple scalar,
+     *  a YamlMapping or a YamlSequence.
+     * @return The found YamlNode or null if nothing is found.
+     */
+    YamlNode value(final YamlNode key);
+
+    /**
      * Fetch the values of this mapping.
      * @return Collection of {@link YamlNode}
      */
-    Collection<YamlNode> values();
-
+    default Collection<YamlNode> values() {
+        final List<YamlNode> values = new LinkedList<>();
+        for(final YamlNode key : this.keys()) {
+            values.add(this.value(key));
+        }
+        return values;
+    }
     /**
      * Get the Yaml mapping associated with the given key.
      * @param key String key
@@ -166,14 +181,6 @@ public interface YamlMapping extends YamlNode {
             Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
         );
     }
-
-    /**
-     * Get the YamlNode mapped to the specified key.
-     * @param key YamlNode key. Could be a simple scalar,
-     *  a YamlMapping or a YamlSequence.
-     * @return The found YamlNode or null if nothing is found.
-     */
-    YamlNode value(final YamlNode key);
 
     /**
      * Convenience method to directly read an integer value

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -38,7 +38,7 @@ import java.util.Set;
 /**
  * A Yaml mapping.
  * @checkstyle ExecutableStatementCount (300 lines)
- * @checkstyle ReturnCount (400 lines)
+ * @checkstyle ReturnCount (1000 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -174,8 +174,16 @@ public interface YamlMapping extends YamlNode {
      * @return String or null if the key is missing, or not pointing
      *  to a folded block scalar.
      */
-    String foldedBlockScalar(final YamlNode key);
-
+    default String foldedBlockScalar(final YamlNode key) {
+        final YamlNode value = this.value(key);
+        final String found;
+        if (value != null  && value instanceof Scalar) {
+            found = ((Scalar) value).value();
+        } else {
+            found = null;
+        }
+        return found;
+    }
     /**
      * Get the String lines of the literal block scalar associated
      * with the given key.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -188,7 +188,7 @@ public interface YamlMapping extends YamlNode {
      * Get the String lines of the literal block scalar associated
      * with the given key.
      * @param key String key
-     * @return Collection of string or null if the key is missing,
+     * @return Collection of String or null if the key is missing,
      *  or not pointing to a literal block scalar.
      */
     default Collection<String> literalBlockScalar(final String key) {
@@ -198,10 +198,11 @@ public interface YamlMapping extends YamlNode {
     }
 
     /**
-     * Get the String folded block scalar associated with the given key.
+     * Get the String lines of the literal block scalar associated
+     * with the given key.
      * @param key String key
-     * @return String or null if the key is missing, or not pointing
-     *  to a folded block scalar.
+     * @return Collection of String or null if the key is missing,
+     *  or not pointing to a literal block scalar.
      */
     Collection<String> literalBlockScalar(final YamlNode key);
 

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -177,7 +177,7 @@ public interface YamlMapping extends YamlNode {
     default String foldedBlockScalar(final YamlNode key) {
         final YamlNode value = this.value(key);
         final String found;
-        if (value != null  && value instanceof Scalar) {
+        if (value != null  && value instanceof BaseFoldedScalar) {
             found = ((Scalar) value).value();
         } else {
             found = null;

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -30,10 +30,7 @@ package com.amihaiemil.eoyaml;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.Collection;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Set;
+import java.util.*;
 
 /**
  * A Yaml mapping.
@@ -204,8 +201,20 @@ public interface YamlMapping extends YamlNode {
      * @return Collection of String or null if the key is missing,
      *  or not pointing to a literal block scalar.
      */
-    Collection<String> literalBlockScalar(final YamlNode key);
-
+    default Collection<String> literalBlockScalar(final YamlNode key) {
+        final Collection<String> found;
+        final YamlNode value = this.value(key);
+        if(value instanceof Scalar) {
+            found = Arrays.asList(
+                ((Scalar) value)
+                    .value()
+                    .split(System.lineSeparator())
+            );
+        } else {
+            found = null;
+        }
+        return found;
+    }
     /**
      * Get the YamlNode mapped to the specified key.
      * @param key String key.

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -128,11 +128,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public Collection<YamlNode> values() {
-        return this.merged.values();
-    }
-
-    @Override
     public YamlNode value(final YamlNode key) {
         return this.merged.value(key);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -138,11 +138,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String foldedBlockScalar(final YamlNode key) {
-        return this.merged.foldedBlockScalar(key);
-    }
-
-    @Override
     public Collection<String> literalBlockScalar(final YamlNode key) {
         return this.merged.literalBlockScalar(key);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -138,11 +138,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlSequence yamlSequence(final YamlNode key) {
-        return this.merged.yamlSequence(key);
-    }
-
-    @Override
     public String string(final YamlNode key) {
         return this.merged.string(key);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -138,11 +138,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public YamlMapping yamlMapping(final YamlNode key) {
-        return this.merged.yamlMapping(key);
-    }
-
-    @Override
     public YamlSequence yamlSequence(final YamlNode key) {
         return this.merged.yamlSequence(key);
     }

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -29,7 +29,6 @@ package com.amihaiemil.eoyaml.extensions;
 
 import com.amihaiemil.eoyaml.*;
 
-import java.util.Collection;
 import java.util.Set;
 import java.util.function.Supplier;
 
@@ -135,11 +134,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     @Override
     public Comment comment() {
         return this.merged.comment();
-    }
-
-    @Override
-    public Collection<String> literalBlockScalar(final YamlNode key) {
-        return this.merged.literalBlockScalar(key);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/extensions/MergedYamlMapping.java
@@ -138,11 +138,6 @@ public final class MergedYamlMapping extends BaseYamlMapping {
     }
 
     @Override
-    public String string(final YamlNode key) {
-        return this.merged.string(key);
-    }
-
-    @Override
     public String foldedBlockScalar(final YamlNode key) {
         return this.merged.foldedBlockScalar(key);
     }

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -27,10 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.LinkedHashMap;
-import java.util.Map;
+import java.util.*;
 
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
@@ -148,7 +145,7 @@ public final class StrictYamlMappingTest {
     public void exceptionOnNullLiteralBlockScalarString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         PlainStringScalar key = new PlainStringScalar("key");
-        Mockito.when(origin.literalBlockScalar(key)).thenReturn(null);
+        Mockito.when(origin.value(key)).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.literalBlockScalar(key);
     }
@@ -227,8 +224,10 @@ public final class StrictYamlMappingTest {
     public void returnsLiteralBlockScalar() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlNode key = new PlainStringScalar("key");
-        Collection<String> lines = Mockito.mock(Collection.class);
-        Mockito.when(origin.literalBlockScalar(key)).thenReturn(lines);
+        List<String> lines = Arrays.asList("line1", "line2");
+        Mockito.when(origin.value(key)).thenReturn(
+            new RtYamlScalarBuilder.BuiltLiteralBlockScalar(lines)
+        );
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.literalBlockScalar(key),

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -108,7 +108,7 @@ public final class StrictYamlMappingTest {
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        Mockito.when(origin.string("key")).thenReturn(null);
+        Mockito.when(origin.value("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.string("key");
     }
@@ -189,7 +189,10 @@ public final class StrictYamlMappingTest {
     public void returnsString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlNode key = new PlainStringScalar("key");
-        Mockito.when(origin.string(key)).thenReturn("found");
+        Mockito.when(origin.value(key)).thenReturn(
+            new PlainStringScalar("found")
+
+        );
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.string("key"), Matchers.equalTo("found")

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -84,7 +84,7 @@ public final class StrictYamlMappingTest {
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullMapping() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        Mockito.when(origin.yamlMapping("key")).thenReturn(null);
+        Mockito.when(origin.value("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.yamlMapping("key");
     }
@@ -160,7 +160,7 @@ public final class StrictYamlMappingTest {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlMapping found = Mockito.mock(YamlMapping.class);
         YamlNode key = new PlainStringScalar("key");
-        Mockito.when(origin.yamlMapping(key)).thenReturn(found);
+        Mockito.when(origin.value(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.yamlMapping("key"), Matchers.equalTo(found)

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -27,6 +27,7 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.Map;
@@ -134,7 +135,7 @@ public final class StrictYamlMappingTest {
     public void exceptionOnNullFoldedBlockScalarString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         PlainStringScalar key = new PlainStringScalar("key");
-        Mockito.when(origin.foldedBlockScalar(key)).thenReturn(null);
+        Mockito.when(origin.value(key)).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.foldedBlockScalar(key);
     }
@@ -207,7 +208,10 @@ public final class StrictYamlMappingTest {
     public void returnsFoldedBlockScalarString() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlNode key = new PlainStringScalar("key");
-        Mockito.when(origin.foldedBlockScalar(key)).thenReturn("found");
+        final Scalar found = new RtYamlScalarBuilder.BuiltFoldedBlockScalar(
+            Arrays.asList("found")
+        );
+        Mockito.when(origin.value(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.foldedBlockScalar(key),

--- a/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StrictYamlMappingTest.java
@@ -96,7 +96,7 @@ public final class StrictYamlMappingTest {
     @Test (expected = YamlNodeNotFoundException.class)
     public void exceptionOnNullSequence() {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
-        Mockito.when(origin.yamlSequence("key")).thenReturn(null);
+        Mockito.when(origin.value("key")).thenReturn(null);
         YamlMapping strict = new StrictYamlMapping(origin);
         strict.yamlSequence("key");
     }
@@ -175,7 +175,7 @@ public final class StrictYamlMappingTest {
         YamlMapping origin = Mockito.mock(YamlMapping.class);
         YamlSequence found = Mockito.mock(YamlSequence.class);
         YamlNode key = new PlainStringScalar("key");
-        Mockito.when(origin.yamlSequence(key)).thenReturn(found);
+        Mockito.when(origin.value(key)).thenReturn(found);
         YamlMapping strict = new StrictYamlMapping(origin);
         MatcherAssert.assertThat(
             strict.yamlSequence("key"), Matchers.equalTo(found)


### PR DESCRIPTION
fixes #317 
All value-accessor methods besides ``value(YamlNode)`` have a default implementation valid for any YamlMapping implementation.