### PR TITLE
#357 read escaped keys correctly

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -179,23 +179,34 @@ final class ReadYamlMapping extends BaseYamlMapping {
      * The YamlNode value associated with a String (scalar) key.
      * @param key String key.
      * @return YamlNode.
+     * @checkstyle ReturnCount (50 lines)
      */
     private YamlNode valueOfStringKey(final String key) {
         YamlNode value = null;
-        for (final YamlLine line : this.significant) {
-            final String trimmed = line.trimmed();
-            if(trimmed.endsWith(key + ":")
-                || trimmed.matches("^" + key + "\\:[ ]*\\>$")
-                || trimmed.matches("^" + key + "\\:[ ]*\\|$")
-            ) {
-                value = this.significant.toYamlNode(line);
-            } else if(trimmed.startsWith(key + ":")
-                && trimmed.length() > 1
-            ) {
-                value = new ReadPlainScalar(this.all, line);
+        final String[] keys = new String[] {
+            key,
+            "\"" + key + "\"",
+            "'" + key + "'",
+        };
+        for(final String tryKey : keys) {
+            for (final YamlLine line : this.significant) {
+                final String trimmed = line.trimmed();
+                if(trimmed.endsWith(tryKey + ":")
+                    || trimmed.matches("^" + tryKey + "\\:[ ]*\\>$")
+                    || trimmed.matches("^" + tryKey + "\\:[ ]*\\|$")
+                ) {
+                    value = this.significant.toYamlNode(line);
+                } else if(trimmed.startsWith(tryKey + ":")
+                    && trimmed.length() > 1
+                ) {
+                    value = new ReadPlainScalar(this.all, line);
+                }
+                if(value != null) {
+                    return value;
+                }
             }
         }
-        return value;
+        return null;
     }
 
     /**

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -1062,4 +1062,19 @@ public final class ReadYamlMappingTest {
 
         MatcherAssert.assertThat(map.yamlSequence(key), Matchers.nullValue());
     }
+
+    /**
+     * ReadYamlMapping returns the correct value
+     * when the key is wrapped in quotes.
+     */
+    @Test
+    public void returnsValueOfStringKeyWithQuotes() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("\"a-key\": someValue", 0));
+        final YamlMapping map = new ReadYamlMapping(new AllYamlLines(lines));
+        MatcherAssert.assertThat(
+            map.string("a-key"),
+            Matchers.equalTo("someValue")
+        );
+    }
 }


### PR DESCRIPTION
PR for #357 

String keys in a  YamlMapping might be escaped (between ``'`` or ``"``).