### PR TITLE
#325 Fixed mappings starting at dash line in sequences

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -94,8 +94,8 @@ final class AllYamlLines implements YamlLines {
     }
 
     /**
-     * Try to figure out what YAML node (mapping, sequence or scalar) do these
-     * lines represent.
+     * Try to figure out what YAML node (mapping, sequence or scalar) is found
+     * after the given line.
      * @param prev YamlLine just previous to the node we're trying to find.
      * @return Found YamlNode.
      */

--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -110,10 +110,10 @@ final class AllYamlLines implements YamlLines {
             line -> line.trimmed().startsWith("%"),
             line -> line.trimmed().startsWith("!!")
         ).iterator().next();
-        if(first.trimmed().startsWith("-")) {
-            node = new ReadYamlSequence(prev, this);
-        } else if (first.trimmed().contains(":")){
+        if(first.trimmed().contains(":")) {
             node = new ReadYamlMapping(prev, this);
+        } else if (first.trimmed().startsWith("-")){
+            node = new ReadYamlSequence(prev, this);
         } else if(this.original().size() == 1) {
             node = new ReadPlainScalar(this, first);
         } else {

--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -110,10 +110,10 @@ final class AllYamlLines implements YamlLines {
             line -> line.trimmed().startsWith("%"),
             line -> line.trimmed().startsWith("!!")
         ).iterator().next();
-        if(first.trimmed().contains(":")) {
-            node = new ReadYamlMapping(prev, this);
-        } else if (first.trimmed().startsWith("-")){
+        if (first.trimmed().startsWith("-")){
             node = new ReadYamlSequence(prev, this);
+        } else if(first.trimmed().contains(":")) {
+            node = new ReadYamlMapping(prev, this);
         } else if(this.original().size() == 1) {
             node = new ReadPlainScalar(this, first);
         } else {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
@@ -70,10 +70,10 @@ final class ReadPlainScalar extends BaseScalar {
     public String value() {
         final String value;
         final String trimmed = this.scalar.trimmed();
-        if(trimmed.startsWith("-") && trimmed.length() > 1) {
-            value = trimmed.substring(trimmed.indexOf('-')+1).trim();
-        } else if(trimmed.contains(":") && !trimmed.endsWith(":")) {
+        if(trimmed.contains(":") && !trimmed.endsWith(":")) {
             value = trimmed.substring(trimmed.indexOf(":") + 1).trim();
+        } else if(trimmed.startsWith("-") && trimmed.length() > 1) {
+            value = trimmed.substring(trimmed.indexOf('-')+1).trim();
         } else {
             value = trimmed;
         }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -119,8 +119,15 @@ final class ReadYamlMapping extends BaseYamlMapping {
                         + "[" + line.trimmed() + "]."
                     );
                 }
-                final String key = trimmed.substring(
-                        0, trimmed.indexOf(":")).trim();
+                final String key;
+                if(trimmed.startsWith("-")) {
+                    key = trimmed.substring(
+                        1, trimmed.indexOf(":")
+                    ).trim();
+                } else {
+                    key = trimmed.substring(
+                        0, trimmed.indexOf(":")
+                    ).trim();                }
                 if(!key.isEmpty()) {
                     keys.add(new PlainStringScalar(key));
                 }
@@ -196,7 +203,8 @@ final class ReadYamlMapping extends BaseYamlMapping {
                     || trimmed.matches("^" + tryKey + "\\:[ ]*\\|$")
                 ) {
                     value = this.significant.toYamlNode(line);
-                } else if(trimmed.startsWith(tryKey + ":")
+                } else if((trimmed.startsWith(tryKey + ":")
+                    || trimmed.startsWith("- " + tryKey + ":"))
                     && trimmed.length() > 1
                 ) {
                     value = new ReadPlainScalar(this.all, line);

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -127,7 +127,8 @@ final class ReadYamlMapping extends BaseYamlMapping {
                 } else {
                     key = trimmed.substring(
                         0, trimmed.indexOf(":")
-                    ).trim();                }
+                    ).trim();
+                }
                 if(!key.isEmpty()) {
                     keys.add(new PlainStringScalar(key));
                 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -102,22 +102,19 @@ final class ReadYamlMapping extends BaseYamlMapping {
     @Override
     public Set<YamlNode> keys() {
         final Set<YamlNode> keys = new LinkedHashSet<>();
+        YamlLine prev = new YamlLine.NullYamlLine();
         for (final YamlLine line : this.significant) {
             final String trimmed = line.trimmed();
-            if(trimmed.startsWith(":")) {
+            if(trimmed.startsWith(":")
+                || (trimmed.startsWith("-")
+                        && !(prev instanceof YamlLine.NullYamlLine))
+            ) {
                 continue;
             } else if ("?".equals(trimmed)) {
                 keys.add(this.significant.toYamlNode(line));
             } else {
                 if(!trimmed.contains(":")) {
-                    throw new YamlReadingException(
-                        "Expected scalar key on line "
-                        + (line.number() + 1) + "."
-                        + " The line should have the format "
-                        + "'key: value' or 'key:'. "
-                        + "Instead, the line is: "
-                        + "[" + line.trimmed() + "]."
-                    );
+                    continue;
                 }
                 final String key;
                 if(trimmed.startsWith("-")) {
@@ -133,6 +130,7 @@ final class ReadYamlMapping extends BaseYamlMapping {
                     keys.add(new PlainStringScalar(key));
                 }
             }
+            prev = line;
         }
         return keys;
     }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -98,15 +98,20 @@ final class ReadYamlSequence extends BaseYamlSequence {
     @Override
     public Collection<YamlNode> values() {
         final List<YamlNode> kids = new LinkedList<>();
+        final boolean foldedSequence = this.previous.trimmed().matches(
+            "^.*\\|.*\\-$"
+        );
         for(final YamlLine line : this.significant) {
             final String trimmed = line.trimmed();
-            if("-".equals(trimmed)
-                || trimmed.endsWith("|")
-                || trimmed.endsWith(">")
-            ) {
-                kids.add(this.significant.toYamlNode(line));
-            } else {
-                kids.add(new ReadPlainScalar(this.all, line));
+            if(foldedSequence || trimmed.startsWith("-")) {
+                if ("-".equals(trimmed)
+                    || trimmed.endsWith("|")
+                    || trimmed.endsWith(">")
+                ) {
+                    kids.add(this.significant.toYamlNode(line));
+                } else {
+                    kids.add(new ReadPlainScalar(this.all, line));
+                }
             }
         }
         return kids;

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -101,7 +101,6 @@ final class ReadYamlSequence extends BaseYamlSequence {
         final boolean foldedSequence = this.previous.trimmed().matches(
             "^.*\\|.*\\-$"
         );
-        YamlLine prev = new YamlLine.NullYamlLine();
         for(final YamlLine line : this.significant) {
             final String trimmed = line.trimmed();
             if(foldedSequence || trimmed.startsWith("-")) {
@@ -112,13 +111,19 @@ final class ReadYamlSequence extends BaseYamlSequence {
                     kids.add(this.significant.toYamlNode(line));
                 } else {
                     if(trimmed.matches("^.*\\-.*\\:.*$")) {
-                        kids.add(this.significant.toYamlNode(prev));
+                        kids.add(
+                            new ReadYamlMapping(
+                                new RtYamlLine(
+                                    "# Mapping at dash line", line.number()-1
+                                ),
+                                this.all
+                            )
+                        );
                     } else {
                         kids.add(new ReadPlainScalar(this.all, line));
                     }
                 }
             }
-            prev = line;
         }
         return kids;
     }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -101,6 +101,7 @@ final class ReadYamlSequence extends BaseYamlSequence {
         final boolean foldedSequence = this.previous.trimmed().matches(
             "^.*\\|.*\\-$"
         );
+        YamlLine prev = new YamlLine.NullYamlLine();
         for(final YamlLine line : this.significant) {
             final String trimmed = line.trimmed();
             if(foldedSequence || trimmed.startsWith("-")) {
@@ -110,9 +111,14 @@ final class ReadYamlSequence extends BaseYamlSequence {
                 ) {
                     kids.add(this.significant.toYamlNode(line));
                 } else {
-                    kids.add(new ReadPlainScalar(this.all, line));
+                    if(trimmed.matches("^.*\\-.*\\:.*$")) {
+                        kids.add(this.significant.toYamlNode(prev));
+                    } else {
+                        kids.add(new ReadPlainScalar(this.all, line));
+                    }
                 }
             }
+            prev = line;
         }
         return kids;
     }

--- a/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
+++ b/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
@@ -77,7 +77,7 @@ final class SameIndentationLevel implements YamlLines {
             final YamlLine first = iterator.next();
             sameIndentation.add(first);
             int firstIndentation = first.indentation();
-            if(first.trimmed().matches("^[ ]*\\-.*\\:.*$")) {
+            if(first.trimmed().matches("^[ ]*\\-.*\\:.+$")) {
                 firstIndentation += 2;
             }
             while (iterator.hasNext()) {

--- a/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
+++ b/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
@@ -76,11 +76,15 @@ final class SameIndentationLevel implements YamlLines {
             final List<YamlLine> sameIndentation = new ArrayList<>();
             final YamlLine first = iterator.next();
             sameIndentation.add(first);
+            int firstIndentation = first.indentation();
+            if(first.trimmed().matches("^[ ]*\\-.*\\:.*$")) {
+                firstIndentation += 2;
+            }
             while (iterator.hasNext()) {
                 YamlLine current = iterator.next();
-                if(current.indentation() == first.indentation()) {
+                if(current.indentation() == firstIndentation) {
                     sameIndentation.add(current);
-                } else if (current.indentation() < first.indentation()) {
+                } else if (current.indentation() < firstIndentation) {
                     break;
                 }
             }

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -102,9 +102,12 @@ final class WellIndented implements YamlLines {
                 YamlLine line = iterator.next();
                 if(!(previous instanceof YamlLine.NullYamlLine)) {
                     int prevIndent = previous.indentation();
+                    if(previous.trimmed().matches("^[ ]*\\-.*\\:$")) {
+                        prevIndent += 2;
+                    }
                     int lineIndent = line.indentation();
                     if(previous.requireNestedIndentation()) {
-                        if(lineIndent != prevIndent+2) {
+                        if(lineIndent != prevIndent + 2) {
                             throw new YamlIndentationException(
                                 "Indentation of line " + (line.number() + 1)
                                 + " is not ok. It should be greater than the one"

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -102,7 +102,7 @@ final class WellIndented implements YamlLines {
                 YamlLine line = iterator.next();
                 if(!(previous instanceof YamlLine.NullYamlLine)) {
                     int prevIndent = previous.indentation();
-                    if(previous.trimmed().matches("^[ ]*\\-.*\\:$")) {
+                    if(previous.trimmed().matches("^[ ]*\\-.*\\:.*$")) {
                         prevIndent += 2;
                     }
                     int lineIndent = line.indentation();

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -85,7 +85,7 @@ public final class ReadYamlSequenceTest {
         lines.add(new RtYamlLine("- alfa:", 2));
         lines.add(new RtYamlLine("    key: value", 3));
         lines.add(new RtYamlLine("    key2: value2", 4));
-        lines.add(new RtYamlLine("- scalar2", 1));
+        lines.add(new RtYamlLine("- scalar2", 5));
         final YamlSequence sequence = new ReadYamlSequence(
             new AllYamlLines(lines)
         );
@@ -99,6 +99,9 @@ public final class ReadYamlSequenceTest {
         MatcherAssert.assertThat(
             alfa.yamlMapping("alfa").string("key2"), Matchers.equalTo("value2")
         );
+        for(final YamlNode value : sequence.values()) {
+            System.out.println(value.type());
+        }
     }
 
     /**
@@ -113,7 +116,7 @@ public final class ReadYamlSequenceTest {
         lines.add(new RtYamlLine("- alfa: beta", 2));
         lines.add(new RtYamlLine("  teta: gama", 3));
         lines.add(new RtYamlLine("  omega: value", 4));
-        lines.add(new RtYamlLine("- scalar2", 1));
+        lines.add(new RtYamlLine("- scalar2", 5));
         final YamlSequence sequence = new ReadYamlSequence(
                 new AllYamlLines(lines)
         );

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -120,7 +120,9 @@ public final class ReadYamlSequenceTest {
         System.out.println(sequence);
         final YamlMapping dashMap = sequence.yamlMapping(2);
         MatcherAssert.assertThat(dashMap, Matchers.notNullValue());
-        MatcherAssert.assertThat(dashMap, Matchers.instanceOf(YamlMapping.class));
+        MatcherAssert.assertThat(
+            dashMap, Matchers.instanceOf(YamlMapping.class)
+        );
         MatcherAssert.assertThat(
             dashMap.string("alfa"), Matchers.equalTo("beta")
         );

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -48,6 +48,7 @@ public final class ReadYamlSequenceTest {
 
     /**
      * ReadYamlSequence can return the YamlMapping from a given index.
+     * The YamlMapping starts after the dash line.
      */
     @Test
     public void returnsYamlMappingFromIndex(){
@@ -68,6 +69,66 @@ public final class ReadYamlSequenceTest {
         MatcherAssert.assertThat(alfa, Matchers.instanceOf(YamlMapping.class));
         MatcherAssert.assertThat(
             alfa.yamlMapping("alfa").string("key"), Matchers.equalTo("value")
+        );
+    }
+
+    /**
+     * ReadYamlSequence can return the YamlMapping which starts right
+     * at the dash line. The YamlMapping has a scalar key and another mapping
+     * as value of this key.
+     */
+    @Test
+    public void returnsYamlMappingWithMappingValueStartingAtDash(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- scalar0", 0));
+        lines.add(new RtYamlLine("- scalar1", 1));
+        lines.add(new RtYamlLine("- alfa:", 2));
+        lines.add(new RtYamlLine("    key: value", 3));
+        lines.add(new RtYamlLine("    key2: value2", 4));
+        lines.add(new RtYamlLine("- scalar2", 1));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping alfa = sequence.yamlMapping(2);
+        MatcherAssert.assertThat(alfa, Matchers.notNullValue());
+        MatcherAssert.assertThat(alfa, Matchers.instanceOf(YamlMapping.class));
+        MatcherAssert.assertThat(
+            alfa.yamlMapping("alfa").string("key"), Matchers.equalTo("value")
+        );
+        MatcherAssert.assertThat(
+            alfa.yamlMapping("alfa").string("key2"), Matchers.equalTo("value2")
+        );
+    }
+
+    /**
+     * ReadYamlSequence can return the YamlMapping which starts right
+     * at the dash line.
+     */
+    @Test
+    public void returnsYamlMappingWithScalarValuesStartingAtDash(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- scalar0", 0));
+        lines.add(new RtYamlLine("- scalar1", 1));
+        lines.add(new RtYamlLine("- alfa: beta", 2));
+        lines.add(new RtYamlLine("  teta: gama", 3));
+        lines.add(new RtYamlLine("  omega: value", 4));
+        lines.add(new RtYamlLine("- scalar2", 1));
+        final YamlSequence sequence = new ReadYamlSequence(
+                new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping dashMap = sequence.yamlMapping(2);
+        MatcherAssert.assertThat(dashMap, Matchers.notNullValue());
+        MatcherAssert.assertThat(dashMap, Matchers.instanceOf(YamlMapping.class));
+        MatcherAssert.assertThat(
+            dashMap.string("alfa"), Matchers.equalTo("beta")
+        );
+        MatcherAssert.assertThat(
+            dashMap.string("teta"), Matchers.equalTo("gama")
+        );
+        MatcherAssert.assertThat(
+            dashMap.string("omega"), Matchers.equalTo("value")
         );
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -606,6 +606,48 @@ public final class RtYamlInputTest {
     }
 
     /**
+     * A YamlSequence containing mappings which start on the
+     * same line as the dash can be read.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void readsSequenceWithDashMappings() throws Exception {
+        final YamlMapping map = Yaml.createYamlInput(
+            this.readTestResource("dashMappings.yml")
+        ).readYamlMapping();
+        MatcherAssert.assertThat(map.type(), Matchers.is(Node.MAPPING));
+        final YamlSequence permissions = map.yamlSequence("permissions");
+        MatcherAssert.assertThat(
+            permissions,
+            Matchers.iterableWithSize(4)
+        );
+        MatcherAssert.assertThat(
+            permissions
+                .yamlMapping(0)
+                .yamlSequence("john"),
+            Matchers.iterableWithSize(2)
+        );
+        MatcherAssert.assertThat(
+            permissions
+                .yamlMapping(1)
+                .yamlSequence("jane"),
+            Matchers.iterableWithSize(2)
+        );
+        MatcherAssert.assertThat(
+            permissions
+                .yamlMapping(2)
+                .string("andrew"),
+            Matchers.equalTo("none")
+        );
+        MatcherAssert.assertThat(
+            permissions
+                .yamlMapping(3)
+                .string("andreea"),
+            Matchers.equalTo("none")
+        );
+    }
+
+    /**
      * Read a test resource file's contents.
      * @param fileName File to read.
      * @return File's contents as String.

--- a/src/test/resources/dashMappings.yml
+++ b/src/test/resources/dashMappings.yml
@@ -1,0 +1,9 @@
+permissions:
+  - john:
+      - download
+      - delete
+  - jane:
+      - deploy
+      - download
+  - andrew: none
+  - andreea: none


### PR DESCRIPTION
PR for #325 

* Bug fixes in indentation validation logic.
* Fixed the reading of mappings which start right at the dash line in a sequence. E.g. first mapping here:

```yaml
- scalar0
- scalar1
- some: mapping
  starting: at-dash
- scalar2
- 
  another: mapping
  onNext: line
```
