### PR TITLE
guessIndentation flag for YamlInput

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -29,6 +29,7 @@ package com.amihaiemil.eoyaml;
 
 import com.amihaiemil.eoyaml.exceptions.YamlReadingException;
 import java.util.Collection;
+import java.util.Iterator;
 
 /**
  * YamlLines default implementation. "All" refers to the fact that
@@ -96,6 +97,11 @@ final class AllYamlLines implements YamlLines {
             }
         }
         return node;
+    }
+
+    @Override
+    public Iterator<YamlLine> iterator() {
+        return this.lines.iterator();
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -72,7 +72,10 @@ final class AllYamlLines implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
         final YamlNode node;
         final String prevLine = prev.trimmed();
         if(prevLine.isEmpty()) {

--- a/src/main/java/com/amihaiemil/eoyaml/FirstCommentFound.java
+++ b/src/main/java/com/amihaiemil/eoyaml/FirstCommentFound.java
@@ -106,7 +106,10 @@ final class FirstCommentFound implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.lines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.lines.toYamlNode(prev, guessIndentation);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/GreaterIndentation.java
+++ b/src/main/java/com/amihaiemil/eoyaml/GreaterIndentation.java
@@ -96,7 +96,10 @@ final class GreaterIndentation implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.yamlLines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.yamlLines.toYamlNode(prev, guessIndentation);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Indented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Indented.java
@@ -32,7 +32,7 @@ package com.amihaiemil.eoyaml;
  * initial indentation with a given value.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 5.0.4
+ * @since 5.1.0
  */
 final class Indented implements YamlLine {
 

--- a/src/main/java/com/amihaiemil/eoyaml/Indented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Indented.java
@@ -27,49 +27,62 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.*;
-
 /**
- * YamlLines which are being iterated backwards.
+ * An YAML Line indented by us. We override the line's
+ * initial indentation with a given value.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 4.2.0
+ * @since 5.0.4
  */
-final class Backwards implements YamlLines {
+final class Indented implements YamlLine {
 
     /**
-     * YamlLines.
+     * Original YAML line.
      */
-    private final YamlLines lines;
+    private final YamlLine original;
+
+    /**
+     * Given indentation.
+     */
+    private int indentation;
 
     /**
      * Ctor.
-     * @param lines The Yaml lines.
+     * @param original Original YamlLine.
+     * @param indentation Given indentation.
      */
-    Backwards(final YamlLines lines) {
-        this.lines = lines;
+    Indented(final YamlLine original, final int indentation) {
+        this.original = original;
+        this.indentation = indentation;
     }
 
     @Override
-    public Collection<YamlLine> original() {
-        return this.lines.original();
+    public String trimmed() {
+        return this.original.trimmed();
     }
 
     @Override
-    public YamlNode toYamlNode(
-        final YamlLine prev,
-        final boolean guessIndentation
-    ) {
-        return this.lines.toYamlNode(prev, guessIndentation);
+    public String comment() {
+        return this.original.comment();
     }
 
     @Override
-    public Iterator<YamlLine> iterator() {
-        final List<YamlLine> original = new ArrayList<>();
-        for(final YamlLine line : this.lines) {
-            original.add(line);
-        }
-        Collections.reverse(original);
-        return original.iterator();
+    public int number() {
+        return this.original.number();
+    }
+
+    @Override
+    public int indentation() {
+        return this.indentation;
+    }
+
+    @Override
+    public boolean requireNestedIndentation() {
+        return this.original.requireNestedIndentation();
+    }
+
+    @Override
+    public int compareTo(final YamlLine other) {
+        return this.original.compareTo(other);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -153,9 +153,7 @@ final class ReadYamlSequence extends BaseYamlSequence {
                     if(trimmed.matches("^.*\\-.*\\:.*$")) {
                         kids.add(
                             new ReadYamlMapping(
-                                new RtYamlLine(
-                                    "# Mapping at dash line", line.number()-1
-                                ),
+                                new RtYamlLine("", line.number()-1),
                                 this.all,
                                 this.guessIndentation
                             )

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -68,14 +68,27 @@ final class ReadYamlSequence extends BaseYamlSequence {
      * If set to true we will try to guess the correct indentation
      * of misplaced lines.
      */
-    private final boolean guessIndentation = false;
+    private final boolean guessIndentation;
 
     /**
      * Ctor.
      * @param lines Given lines.
      */
     ReadYamlSequence(final AllYamlLines lines) {
-        this(new YamlLine.NullYamlLine(), lines);
+        this(lines, false);
+    }
+
+    /**
+     * Ctor.
+     * @param lines Given lines.
+     * @param guessIndentation If set to true, we will try to
+     *  guess the correct indentation of misplaced lines.
+     */
+    ReadYamlSequence(
+        final AllYamlLines lines,
+        final boolean guessIndentation
+    ) {
+        this(new YamlLine.NullYamlLine(), lines, guessIndentation);
     }
 
     /**
@@ -84,6 +97,21 @@ final class ReadYamlSequence extends BaseYamlSequence {
      * @param lines Given lines.
      */
     ReadYamlSequence(final YamlLine previous, final AllYamlLines lines) {
+        this(previous, lines, false);
+    }
+
+    /**
+     * Ctor.
+     * @param previous Line just before the start of this sequence.
+     * @param lines Given lines.
+     * @param guessIndentation If set to true, we will try to guess the
+     *  correct indentation of misplaced lines.
+     */
+    ReadYamlSequence(
+        final YamlLine previous,
+        final AllYamlLines lines,
+        final boolean guessIndentation
+    ) {
         this.previous = previous;
         this.all = lines;
         this.significant = new SameIndentationLevel(
@@ -96,9 +124,11 @@ final class ReadYamlSequence extends BaseYamlSequence {
                     line -> line.trimmed().startsWith("..."),
                     line -> line.trimmed().startsWith("%"),
                     line -> line.trimmed().startsWith("!!")
-                )
+                ),
+                guessIndentation
             )
         );
+        this.guessIndentation = guessIndentation;
     }
 
     @Override
@@ -126,7 +156,8 @@ final class ReadYamlSequence extends BaseYamlSequence {
                                 new RtYamlLine(
                                     "# Mapping at dash line", line.number()-1
                                 ),
-                                this.all
+                                this.all,
+                                this.guessIndentation
                             )
                         );
                     } else {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -65,6 +65,12 @@ final class ReadYamlSequence extends BaseYamlSequence {
     private final YamlLines significant;
 
     /**
+     * If set to true we will try to guess the correct indentation
+     * of misplaced lines.
+     */
+    private final boolean guessIndentation = false;
+
+    /**
      * Ctor.
      * @param lines Given lines.
      */
@@ -108,7 +114,11 @@ final class ReadYamlSequence extends BaseYamlSequence {
                     || trimmed.endsWith("|")
                     || trimmed.endsWith(">")
                 ) {
-                    kids.add(this.significant.toYamlNode(line));
+                    kids.add(
+                        this.significant.toYamlNode(
+                            line, this.guessIndentation
+                        )
+                    );
                 } else {
                     if(trimmed.matches("^.*\\-.*\\:.*$")) {
                         kids.add(

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
@@ -53,13 +53,23 @@ final class ReadYamlStream extends BaseYamlStream {
      * If set to true we will try to guess the correct indentation
      * of misplaced lines.
      */
-    private final boolean guessIndentation = false;
+    private final boolean guessIndentation;
 
     /**
      * Constructor.
      * @param lines All YAML lines as they are read from the input.
      */
     ReadYamlStream(final AllYamlLines lines) {
+        this(lines, false);
+    }
+
+    /**
+     * Constructor.
+     * @param lines All YAML lines as they are read from the input.
+     * @param guessIndentation If set to true, we will try to guess
+     *  the correct indentation of misplaced lines.
+     */
+    ReadYamlStream(final AllYamlLines lines, final boolean guessIndentation) {
         this.startMarkers = new WellIndented(
             new StartMarkers(
                 new Skip(
@@ -74,6 +84,7 @@ final class ReadYamlStream extends BaseYamlStream {
             line -> line.trimmed().startsWith("#"),
             line -> line.trimmed().startsWith("%")
         );
+        this.guessIndentation = guessIndentation;
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlStream.java
@@ -50,6 +50,12 @@ final class ReadYamlStream extends BaseYamlStream {
     private final YamlLines startMarkers;
 
     /**
+     * If set to true we will try to guess the correct indentation
+     * of misplaced lines.
+     */
+    private final boolean guessIndentation = false;
+
+    /**
      * Constructor.
      * @param lines All YAML lines as they are read from the input.
      */
@@ -76,7 +82,11 @@ final class ReadYamlStream extends BaseYamlStream {
         for(final YamlLine startDoc : this.startMarkers) {
             final YamlLines document = this.readDocument(startDoc);
             if(!document.original().isEmpty()) {
-                values.add(document.toYamlNode(startDoc));
+                values.add(
+                    document.toYamlNode(
+                        startDoc, this.guessIndentation
+                    )
+                );
             }
         }
         return values;

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
@@ -75,17 +75,17 @@ final class RtYamlInput implements YamlInput {
 
     @Override
     public YamlMapping readYamlMapping() throws IOException {
-        return new ReadYamlMapping(this.readInput());
+        return new ReadYamlMapping(this.readInput(), this.guessIndentation);
     }
 
     @Override
     public YamlSequence readYamlSequence() throws IOException {
-        return new ReadYamlSequence(this.readInput());
+        return new ReadYamlSequence(this.readInput(), this.guessIndentation);
     }
 
     @Override
     public YamlStream readYamlStream() throws IOException {
-        return new ReadYamlStream(this.readInput());
+        return new ReadYamlStream(this.readInput(), this.guessIndentation);
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
@@ -46,14 +46,31 @@ final class RtYamlInput implements YamlInput {
     /**
      * Source of the input.
      */
-    private InputStream source;
+    private final InputStream source;
+
+    /**
+     * If set to true, we will try to guess the correct indentation
+     * of misplaced lines.
+     */
+    private final boolean guessIndentation;
 
     /**
      * Ctor.
      * @param source Given source.
      */
     RtYamlInput(final InputStream source) {
+        this(source, false);
+    }
+
+    /**
+     * Ctor.
+     * @param source Given source.
+     * @param guessIndentation If set to true, we will try to guess
+     *  the correct indentation of misplaced lines.
+     */
+    RtYamlInput(final InputStream source, final boolean guessIndentation) {
         this.source = source;
+        this.guessIndentation = guessIndentation;
     }
 
     @Override

--- a/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
+++ b/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
@@ -99,8 +99,11 @@ final class SameIndentationLevel implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.yamlLines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.yamlLines.toYamlNode(prev, guessIndentation);
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Skip.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Skip.java
@@ -91,8 +91,11 @@ final class Skip implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.yamlLines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.yamlLines.toYamlNode(prev, guessIndentation);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/StartMarkers.java
+++ b/src/main/java/com/amihaiemil/eoyaml/StartMarkers.java
@@ -103,7 +103,10 @@ final class StartMarkers implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.yamlLines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.yamlLines.toYamlNode(prev, guessIndentation);
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -36,11 +36,6 @@ import java.util.List;
 /**
  * YamlLines decorator which iterates over them and verifies
  * that their indentation is correct.<br><br>
- * Initially, we used to do this validation at line level, right when each
- * line is being read (in {@link RtYamlInput}). However, we decided
- * to do it at YamlLines level, as a decorator, because
- * in some cases, we need to eliminate some of them first (markers,
- * directives etc). <br><br>
  *
  * This class can be used as follows:
  *
@@ -75,11 +70,30 @@ final class WellIndented implements YamlLines {
     private final YamlLines yamlLines;
 
     /**
+     * If this is true, then we will try to adjust a wrong indentation,
+     * instead of throwin an exception. This mechanism is not safe becuase
+     * the resulting YAML might not be the expected one.
+     */
+    private final boolean guessIndentation;
+
+    /**
      * Ctor.
      * @param yamlLines The Yaml lines.
      */
     WellIndented(final YamlLines yamlLines) {
+        this(yamlLines, false);
+    }
+
+    /**
+     * Ctor.
+     * @param yamlLines The Yaml lines.
+     * @param guessIndentation If indentation is not correct, try to
+     *  adjust it instead of throwing an exception. This mechanism is not
+     *  safe because the resulting YAML might not be the expected one.
+     */
+    WellIndented(final YamlLines yamlLines, final boolean guessIndentation) {
         this.yamlLines = yamlLines;
+        this.guessIndentation = guessIndentation;
     }
 
     /**
@@ -108,21 +122,29 @@ final class WellIndented implements YamlLines {
                     int lineIndent = line.indentation();
                     if(previous.requireNestedIndentation()) {
                         if(lineIndent != prevIndent + 2) {
-                            throw new YamlIndentationException(
-                                "Indentation of line " + (line.number() + 1)
-                                + " is not ok. It should be greater than the one"
-                                + " of line " + (previous.number() + 1)
-                                + " by 2 spaces."
-                            );
+                            if(this.guessIndentation) {
+                                line = new Indented(line, prevIndent + 2);
+                            } else {
+                                throw new YamlIndentationException(
+                                    "Indentation of line " + (line.number() + 1)
+                                  + " is not ok. It should be greater than the one"
+                                  + " of line " + (previous.number() + 1)
+                                  + " by 2 spaces."
+                                );
+                            }
                         }
                     } else {
                         if(!"---".equals(previous.trimmed()) && lineIndent > prevIndent) {
-                            throw new YamlIndentationException(
-                                "Indentation of line " + (line.number() +1) + " is "
-                                + "greater than the one of line "
-                                + (previous.number() + 1) + ". "
-                                + "It should be less or equal."
-                            );
+                            if(this.guessIndentation) {
+                                line = new Indented(line, prevIndent);
+                            } else {
+                                throw new YamlIndentationException(
+                                    "Indentation of line " + (line.number() + 1) + " is "
+                                  + "greater than the one of line "
+                                  + (previous.number() + 1) + ". "
+                                  + "It should be less or equal."
+                                );
+                            }
                         }
                     }
                 }
@@ -139,8 +161,11 @@ final class WellIndented implements YamlLines {
     }
 
     @Override
-    public YamlNode toYamlNode(final YamlLine prev) {
-        return this.yamlLines.toYamlNode(prev);
+    public YamlNode toYamlNode(
+        final YamlLine prev,
+        final boolean guessIndentation
+    ) {
+        return this.yamlLines.toYamlNode(prev, guessIndentation);
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -56,7 +56,9 @@ import java.util.List;
  *     )
  * );//Iterate over the lines which are at the same indentation level
  * </pre>
- *
+ * @checkstyle ExecutableStatementCount (400 lines)
+ * @checkstyle CyclomaticComplexity (400 lines)
+ * @checkstyle NestedIfDepth (400 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.2
@@ -163,9 +165,9 @@ final class WellIndented implements YamlLines {
     @Override
     public YamlNode toYamlNode(
         final YamlLine prev,
-        final boolean guessIndentation
+        final boolean guessIndent
     ) {
-        return this.yamlLines.toYamlNode(prev, guessIndentation);
+        return this.yamlLines.toYamlNode(prev, guessIndent);
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Yaml.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Yaml.java
@@ -83,7 +83,26 @@ public final class Yaml {
      */
     public static YamlInput createYamlInput(final File input)
         throws FileNotFoundException {
-        return Yaml.createYamlInput(new FileInputStream(input));
+        return Yaml.createYamlInput(input, Boolean.FALSE);
+    }
+
+    /**
+     * Create a {@link YamlInput} from a File.
+     * @return YamlInput, reader of Yaml.
+     * @param input File to read from.
+     * @param guessIndentation If set to true, we will try to guess the correct
+     *  indentation of misplaced lines. The default value is false
+     *  and an exception is thrown if indentation is not correct.
+     * @throws FileNotFoundException If the file is not found.
+     */
+    public static YamlInput createYamlInput(
+        final File input,
+        final boolean guessIndentation
+    ) throws FileNotFoundException {
+        return Yaml.createYamlInput(
+            new FileInputStream(input),
+            guessIndentation
+        );
     }
 
     /**
@@ -92,8 +111,24 @@ public final class Yaml {
      * @return YamlInput, reader of Yaml.
      */
     public static YamlInput createYamlInput(final String input) {
+        return Yaml.createYamlInput(input, Boolean.FALSE);
+    }
+
+    /**
+     * Create a {@link YamlInput} from a String.
+     * @param input String to read from.
+     * @param guessIndentation If set to true, we will try to guess the correct
+     *  indentation of misplaced lines. The default value is false
+     *  and an exception is thrown if indentation is not correct.
+     * @return YamlInput, reader of Yaml.
+     */
+    public static YamlInput createYamlInput(
+        final String input,
+        final boolean guessIndentation
+    ) {
         return Yaml.createYamlInput(
-            new ByteArrayInputStream(input.getBytes())
+            new ByteArrayInputStream(input.getBytes()),
+            guessIndentation
         );
     }
 
@@ -103,7 +138,22 @@ public final class Yaml {
      * @return YamlInput, reader of Yaml.
      */
     public static YamlInput createYamlInput(final InputStream input) {
-        return new RtYamlInput(input);
+        return Yaml.createYamlInput(input, Boolean.FALSE);
+    }
+
+    /**
+     * Create a {@link YamlInput} from an InputStream.
+     * @param input InputStream to read from.
+     * @param guessIndentation If set to true, we will try to guess the correct
+     *  indentation of misplaced lines. The default value is false
+     *  and an exception is thrown if indentation is not correct.
+     * @return YamlInput, reader of Yaml.
+     */
+    public static YamlInput createYamlInput(
+        final InputStream input,
+        final boolean guessIndentation
+    ) {
+        return new RtYamlInput(input, guessIndentation);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
@@ -61,9 +61,7 @@ interface YamlLines extends Iterable<YamlLine> {
      * iterates over all of them.
      * @return Iterator of YamlLine.
      */
-    default Iterator<YamlLine> iterator() {
-        return this.original().iterator();
-    }
+    Iterator<YamlLine> iterator();
 
     /**
      * Get a certain YamlLine.

--- a/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLines.java
@@ -50,9 +50,11 @@ interface YamlLines extends Iterable<YamlLine> {
     /**
      * Turn these lines into a YamlNode.
      * @param prev Previous YamlLine
+     * @param guessIndentation If set to true, we will try to guess
+     *  the correct indentation of misplaced lines.
      * @return YamlNode
      */
-    YamlNode toYamlNode(final YamlLine prev);
+    YamlNode toYamlNode(final YamlLine prev, final boolean guessIndentation);
 
     /**
      * Default iterator which doesn't skip any line,

--- a/src/test/java/com/amihaiemil/eoyaml/AllYamlLinesTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/AllYamlLinesTest.java
@@ -79,7 +79,10 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("line3", 3));
         final YamlLines yamlLines = new AllYamlLines(lines);
         MatcherAssert.assertThat(
-            yamlLines.toYamlNode(new RtYamlLine("literalScalar:|", 0)),
+            yamlLines.toYamlNode(
+                new RtYamlLine("literalScalar:|", 0),
+                false
+            ),
             Matchers.instanceOf(ReadLiteralBlockScalar.class)
         );
     }
@@ -96,7 +99,10 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("of text", 3));
         final YamlLines yamlLines = new AllYamlLines(lines);
         MatcherAssert.assertThat(
-            yamlLines.toYamlNode(new RtYamlLine("foldedScalar:>", 0)),
+            yamlLines.toYamlNode(
+                new RtYamlLine("foldedScalar:>", 0),
+                false
+            ),
             Matchers.instanceOf(ReadFoldedBlockScalar.class)
         );
     }
@@ -113,7 +119,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("value3", 3));
         final YamlLines yamlLines = new AllYamlLines(lines);
         final YamlNode seq =  yamlLines.toYamlNode(
-            new RtYamlLine("foldedSequence:|-", 0)
+            new RtYamlLine("foldedSequence:|-", 0), false
         );
         MatcherAssert.assertThat(
             seq, Matchers.instanceOf(ReadYamlSequence.class)
@@ -150,7 +156,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("value3", 3));
         final YamlLines yamlLines = new AllYamlLines(lines);
         final YamlNode seq =  yamlLines.toYamlNode(
-            new RtYamlLine("foldedSequence:| -", 0)
+            new RtYamlLine("foldedSequence:| -", 0), false
         );
         MatcherAssert.assertThat(
             seq, Matchers.instanceOf(ReadYamlSequence.class)
@@ -185,7 +191,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("for: test", 2));
         final YamlLines yamlLines = new AllYamlLines(lines);
         MatcherAssert.assertThat(
-            yamlLines.toYamlNode(new RtYamlLine("---", 0)),
+            yamlLines.toYamlNode(new RtYamlLine("---", 0), false),
             Matchers.instanceOf(ReadYamlMapping.class)
         );
     }
@@ -201,7 +207,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("- sequence", 2));
         final YamlLines yamlLines = new AllYamlLines(lines);
         MatcherAssert.assertThat(
-            yamlLines.toYamlNode(new RtYamlLine("?", 0)),
+            yamlLines.toYamlNode(new RtYamlLine("?", 0), false),
             Matchers.instanceOf(ReadYamlSequence.class)
         );
     }
@@ -216,7 +222,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("justAScalar", 1));
         final YamlLines yamlLines = new AllYamlLines(lines);
         MatcherAssert.assertThat(
-            yamlLines.toYamlNode(new RtYamlLine("---", 0)),
+            yamlLines.toYamlNode(new RtYamlLine("---", 0), false),
             Matchers.instanceOf(ReadPlainScalar.class)
         );
     }
@@ -237,7 +243,7 @@ public final class AllYamlLinesTest {
         lines.add(new RtYamlLine("a folded or literal scalar", 4));
         final YamlLines yamlLines = new AllYamlLines(lines);
         try {
-            yamlLines.toYamlNode(new RtYamlLine("---", -1));
+            yamlLines.toYamlNode(new RtYamlLine("---", -1), false);
             Assert.fail("Expected IllegalStateException!");
         } catch (final YamlReadingException ex) {
             final String message = ex.getMessage();

--- a/src/test/java/com/amihaiemil/eoyaml/BackwardsTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BackwardsTest.java
@@ -67,9 +67,9 @@ public final class BackwardsTest {
         final YamlLines initial = Mockito.mock(YamlLines.class);
         final YamlLine prev = Mockito.mock(YamlLine.class);
         final YamlNode node = Mockito.mock(YamlNode.class);
-        Mockito.when(initial.toYamlNode(prev)).thenReturn(node);
+        Mockito.when(initial.toYamlNode(prev, false)).thenReturn(node);
         MatcherAssert.assertThat(
-            new Backwards(initial).toYamlNode(prev),
+            new Backwards(initial).toYamlNode(prev, false),
             Matchers.is(node)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/FirstCommentFoundTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/FirstCommentFoundTest.java
@@ -66,9 +66,9 @@ public final class FirstCommentFoundTest {
         final YamlLines initial = Mockito.mock(YamlLines.class);
         final YamlLine prev = Mockito.mock(YamlLine.class);
         final YamlNode node = Mockito.mock(YamlNode.class);
-        Mockito.when(initial.toYamlNode(prev)).thenReturn(node);
+        Mockito.when(initial.toYamlNode(prev, false)).thenReturn(node);
         MatcherAssert.assertThat(
-            new FirstCommentFound(initial).toYamlNode(prev),
+            new FirstCommentFound(initial).toYamlNode(prev, false),
             Matchers.is(node)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/SkipTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/SkipTest.java
@@ -167,9 +167,9 @@ public final class SkipTest {
         final YamlLines initial = Mockito.mock(YamlLines.class);
         final YamlLine prev = Mockito.mock(YamlLine.class);
         final YamlNode node = Mockito.mock(YamlNode.class);
-        Mockito.when(initial.toYamlNode(prev)).thenReturn(node);
+        Mockito.when(initial.toYamlNode(prev, false)).thenReturn(node);
         MatcherAssert.assertThat(
-            new Skip(initial).toYamlNode(prev),
+            new Skip(initial).toYamlNode(prev, false),
             Matchers.is(node)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/StartMarkersTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/StartMarkersTest.java
@@ -68,9 +68,9 @@ public final class StartMarkersTest {
         final YamlLines lines = Mockito.mock(YamlLines.class);
         final YamlLine prev = Mockito.mock(YamlLine.class);
         final YamlNode result = Mockito.mock(YamlNode.class);
-        Mockito.when(lines.toYamlNode(prev)).thenReturn(result);
+        Mockito.when(lines.toYamlNode(prev, false)).thenReturn(result);
         MatcherAssert.assertThat(
-            new StartMarkers(lines).toYamlNode(prev),
+            new StartMarkers(lines).toYamlNode(prev, false),
             Matchers.is(result)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/WellIndentedTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/WellIndentedTest.java
@@ -70,9 +70,9 @@ public final class WellIndentedTest {
         final YamlLines lines = Mockito.mock(YamlLines.class);
         final YamlLine prev = Mockito.mock(YamlLine.class);
         final YamlNode result = Mockito.mock(YamlNode.class);
-        Mockito.when(lines.toYamlNode(prev)).thenReturn(result);
+        Mockito.when(lines.toYamlNode(prev, false)).thenReturn(result);
         MatcherAssert.assertThat(
-            new WellIndented(lines).toYamlNode(prev),
+            new WellIndented(lines).toYamlNode(prev, false),
             Matchers.is(result)
         );
     }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -27,49 +27,33 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.*;
+import org.junit.Ignore;
+import org.junit.Test;
+
+import java.io.File;
 
 /**
- * YamlLines which are being iterated backwards.
+ * Test cases regarding an input YAML's indentation, particularly
+ * disabling validation of indentation and trying to guess the correct
+ * one.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
- * @since 4.2.0
+ * @since 5.0.4
  */
-final class Backwards implements YamlLines {
+public final class YamlIndentationTestCase {
 
     /**
-     * YamlLines.
+     * A Yaml mapping containing an unindented sequence
+     * can be read.
+     * @throws Exception If something goes wrong.
      */
-    private final YamlLines lines;
-
-    /**
-     * Ctor.
-     * @param lines The Yaml lines.
-     */
-    Backwards(final YamlLines lines) {
-        this.lines = lines;
+    @Test
+    @Ignore
+    public void readsMappingWithUnindentedSequence() throws Exception {
+        final YamlMapping map = Yaml.createYamlInput(
+            new File("src/test/resources/badSequenceIndentationInMapping.yml")
+        ).readYamlMapping();
+        System.out.println(map);
     }
 
-    @Override
-    public Collection<YamlLine> original() {
-        return this.lines.original();
-    }
-
-    @Override
-    public YamlNode toYamlNode(
-        final YamlLine prev,
-        final boolean guessIndentation
-    ) {
-        return this.lines.toYamlNode(prev, guessIndentation);
-    }
-
-    @Override
-    public Iterator<YamlLine> iterator() {
-        final List<YamlLine> original = new ArrayList<>();
-        for(final YamlLine line : this.lines) {
-            original.add(line);
-        }
-        Collections.reverse(original);
-        return original.iterator();
-    }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -111,6 +111,11 @@ public final class YamlIndentationTestCase {
             new File("src/test/resources/badMappingIndentation.yml"),
             Boolean.TRUE
         ).readYamlMapping();
+        System.out.println(map);
+        MatcherAssert.assertThat(
+            map.string("name"),
+            Matchers.equalTo("eo-yaml")
+        );
         MatcherAssert.assertThat(
             map.yamlSequence("developers"),
             Matchers.nullValue()

--- a/src/test/resources/badMappingIndentation.yml
+++ b/src/test/resources/badMappingIndentation.yml
@@ -1,3 +1,4 @@
+name: eo-yaml
 contributors:
 developers:
 - amihaiemil # Elements of this sequence should be indented by 4 spaces.

--- a/src/test/resources/badMappingIndentation.yml
+++ b/src/test/resources/badMappingIndentation.yml
@@ -1,0 +1,5 @@
+contributors:
+developers:
+- amihaiemil # Elements of this sequence should be indented by 4 spaces.
+- sherif
+- rultor

--- a/src/test/resources/badSequenceIndentationInMapping.yml
+++ b/src/test/resources/badSequenceIndentationInMapping.yml
@@ -1,0 +1,4 @@
+developers:
+- mihai # Elements of a child sequence should be indented by 2 spaces.
+- sherif
+- rultor

--- a/src/test/resources/badSequenceIndentationInMapping.yml
+++ b/src/test/resources/badSequenceIndentationInMapping.yml
@@ -1,4 +1,4 @@
 developers:
-- mihai # Elements of a child sequence should be indented by 2 spaces.
+- amihaiemil # Elements of a child sequence should be indented by 2 spaces.
 - sherif
 - rultor


### PR DESCRIPTION
PR for #361 

* All the ``Yaml.createYamlInput(...)`` methods have been overriden to accept the boolean flag ``guessIndentation`` -- if this flag is set to true, we will try to "guess" the correct indentation ourselves (i.e. instead of throwing an exception, we will set the expected indentation for each misplaced line).

* TODO: edit the README/Wiki to reflect this change.