### PR TITLE
#364 fix print with indented comments + test

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlPrinter.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlPrinter.java
@@ -127,11 +127,11 @@ final class RtYamlPrinter implements YamlPrinter {
         while(keysIt.hasNext()) {
             final YamlNode key = keysIt.next();
             this.printPossibleComment(key, alignment.toString());
-            this.writer.append(alignment);
             final YamlNode value = mapping.value(key);
             if(!(value instanceof Scalar)) {
                 this.printPossibleComment(value, alignment.toString());
             }
+            this.writer.append(alignment);
             if(key instanceof Scalar) {
                 this.printScalar((Scalar) key, 0);
                 this.writer

--- a/src/test/java/com/amihaiemil/eoyaml/YamlMappingPrintTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlMappingPrintTest.java
@@ -50,6 +50,25 @@ import java.io.IOException;
  * @since 4.0.0
  */
 public final class YamlMappingPrintTest {
+
+    /**
+     * We read a YamlMapping containing indented nodes and comments
+     * and print it.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void printsReadYamlMappingWithIndentedComment() throws Exception {
+        final YamlMapping read = Yaml.createYamlInput(
+            new File("src/test/resources/printing_tests/yamlMappingIndentedComments.yml")
+        ).readYamlMapping();
+        MatcherAssert.assertThat(
+            read.toString(),
+            Matchers.equalTo(
+                this.readExpected("yamlMappingIndentedComments.yml")
+            )
+        );
+    }
+
     /**
      * We read a YamlMapping containing all types of
      * YamlNode we have so far and print it.

--- a/src/test/resources/printing_tests/yamlMappingIndentedComments.yml
+++ b/src/test/resources/printing_tests/yamlMappingIndentedComments.yml
@@ -1,0 +1,12 @@
+name: "eo-yaml"
+contributors:
+  # Developers here
+  developers:
+    - amihaiemil # Architect
+    - sherif
+    - salijkan
+  # Mostly chatbots
+  devops:
+    - rultor
+    - 0pdd
+    - travis


### PR DESCRIPTION
PR for #364 
A small bugfix regarding printing of YAML mappings which contain indented comments.