### PR TITLE
Benchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,6 +91,12 @@
             <version>1.14</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>2.11.1</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -67,6 +67,24 @@
             <version>2.5</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-core</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.openjdk.jmh</groupId>
+            <artifactId>jmh-generator-annprocess</artifactId>
+            <version>1.23</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.yaml</groupId>
+            <artifactId>snakeyaml</artifactId>
+            <version>1.26</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -85,6 +85,12 @@
             <version>1.26</version>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.esotericsoftware.yamlbeans</groupId>
+            <artifactId>yamlbeans</artifactId>
+            <version>1.14</version>
+            <scope>test</scope>
+        </dependency>
     </dependencies>
     <build>
         <plugins>

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -17,8 +17,6 @@ import org.openjdk.jmh.annotations.*;
 @Measurement(iterations = 3)
 public class BenchmarkRunner {
 
-    private final org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
-
     public static void main(final String[] args) throws IOException {
         Main.main(args);
     }
@@ -40,7 +38,7 @@ public class BenchmarkRunner {
     public void snakeyaml() throws IOException {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
-            this.yaml.load(reader);
+            new org.yaml.snakeyaml.Yaml().load(reader);
         }
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -9,7 +9,7 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.*;
 
-@BenchmarkMode(Mode.Throughput)
+@BenchmarkMode(Mode.AverageTime)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
@@ -56,8 +56,7 @@ public class BenchmarkRunner {
     public void jacksonyaml() throws IOException {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
-            YAMLFactory.builder()
-                .build()
+            new ObjectMapper(new YAMLFactory())
                 .createParser(reader)
                 .readValueAsTree();
         }

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -6,7 +6,7 @@ import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.*;
 
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -1,6 +1,7 @@
 package com.amihaiemil.eoyaml.benchmark;
 
 import com.amihaiemil.eoyaml.Yaml;
+import com.esotericsoftware.yamlbeans.YamlReader;
 import java.io.*;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.Main;
@@ -9,7 +10,7 @@ import org.openjdk.jmh.annotations.*;
 @BenchmarkMode(Mode.Throughput)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
-@Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
+@Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
 @Warmup(iterations = 5)
 @Measurement(iterations = 5)
 public class BenchmarkRunner {
@@ -26,15 +27,27 @@ public class BenchmarkRunner {
 
     @Benchmark
     public void eoyaml() throws IOException {
-        Yaml.createYamlInput(new FileInputStream(
-            new File("target/test-classes/benchmark", "benchmark.yml")), true)
-            .readYamlMapping();
+        try (final InputStream stream =
+                 new FileInputStream(new File("target/test-classes/benchmark", "benchmark.yml"))) {
+            Yaml.createYamlInput(stream, true)
+                .readYamlMapping();
+        }
     }
 
     @Benchmark
-    public void snakeyaml() throws FileNotFoundException {
-        this.yaml.load(new FileInputStream(
-            new File("target/test-classes/benchmark", "benchmark.yml")));
+    public void snakeyaml() throws IOException {
+        try (final Reader reader =
+                 new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
+            this.yaml.load(reader);
+        }
+    }
+
+    @Benchmark
+    public void yamlbeans() throws IOException {
+        try (final Reader reader =
+                 new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
+            new YamlReader(reader).read();
+        }
     }
 
 }

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -2,19 +2,21 @@ package com.amihaiemil.eoyaml.benchmark;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.fasterxml.jackson.core.TreeNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.*;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.Main;
 import org.openjdk.jmh.annotations.*;
 
-@BenchmarkMode(Mode.AverageTime)
+@BenchmarkMode(Mode.All)
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
-@Warmup(iterations = 3)
-@Measurement(iterations = 3)
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
 public class BenchmarkRunner {
 
     public static void main(final String[] args) throws IOException {
@@ -26,37 +28,45 @@ public class BenchmarkRunner {
     }
 
     @Benchmark
-    public void eoyaml() throws IOException {
+    public void eoyamlLoadAndGetString() throws IOException {
         try (final InputStream stream =
                  new FileInputStream(new File("target/test-classes/benchmark", "benchmark.yml"))) {
             Yaml.createYamlInput(stream, true)
-                .readYamlMapping();
+                .readYamlMapping()
+                .yamlMapping("run")
+                .string("benchmarkName");
         }
     }
 
     @Benchmark
-    public void snakeyaml() throws IOException {
+    public void snakeyamlLoadAndGetString() throws IOException {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
-            new org.yaml.snakeyaml.Yaml().load(reader);
+            final Map<Object, Object> map = new org.yaml.snakeyaml.Yaml().load(reader);
+            final Map<Object, Object> run = (Map<Object, Object>) map.get("run");
+            run.get("benchmarkName");
         }
     }
 
     @Benchmark
-    public void yamlbeans() throws IOException {
+    public void yamlbeansLoadAndGetString() throws IOException {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
-            new YamlReader(reader).read();
+            final Map<Object, Object> map = new YamlReader(reader).read(Map.class);
+            final Map<Object, Object> run = (Map<Object, Object>) map.get("run");
+            run.get("benchmarkName");
         }
     }
 
     @Benchmark
-    public void jacksonyaml() throws IOException {
+    public void jacksonyamlLoadAndGetString() throws IOException {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
-            new ObjectMapper(new YAMLFactory())
+            final TreeNode node = new ObjectMapper(new YAMLFactory())
                 .createParser(reader)
                 .readValueAsTree();
+            final TreeNode run = node.get("run");
+            run.get("benchmarkName");
         }
     }
 

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -1,0 +1,40 @@
+package com.amihaiemil.eoyaml.benchmark;
+
+import com.amihaiemil.eoyaml.Yaml;
+import java.io.*;
+import java.util.concurrent.TimeUnit;
+import org.openjdk.jmh.Main;
+import org.openjdk.jmh.annotations.*;
+
+@BenchmarkMode(Mode.AverageTime)
+@OutputTimeUnit(TimeUnit.MILLISECONDS)
+@State(Scope.Benchmark)
+@Fork(value = 2, jvmArgs = {"-Xms2G", "-Xmx2G"})
+@Warmup(iterations = 5)
+@Measurement(iterations = 5)
+public class BenchmarkRunner {
+
+    private final org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
+
+    public static void main(final String[] args) throws IOException {
+        Main.main(args);
+    }
+
+    @Setup
+    public void setup() {
+    }
+
+    @Benchmark
+    public void eoyaml() throws IOException {
+        Yaml.createYamlInput(new FileInputStream(
+            new File("target/test-classes/benchmark", "benchmark.yml")), true)
+            .readYamlMapping();
+    }
+
+    @Benchmark
+    public void snakeyaml() throws FileNotFoundException {
+        this.yaml.load(new FileInputStream(
+            new File("target/test-classes/benchmark", "benchmark.yml")));
+    }
+
+}

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -13,8 +13,8 @@ import org.openjdk.jmh.annotations.*;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
-@Warmup(iterations = 1)
-@Measurement(iterations = 1)
+@Warmup(iterations = 3)
+@Measurement(iterations = 3)
 public class BenchmarkRunner {
 
     private final org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();

--- a/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
+++ b/src/test/java/com/amihaiemil/eoyaml/benchmark/BenchmarkRunner.java
@@ -2,6 +2,8 @@ package com.amihaiemil.eoyaml.benchmark;
 
 import com.amihaiemil.eoyaml.Yaml;
 import com.esotericsoftware.yamlbeans.YamlReader;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
 import java.io.*;
 import java.util.concurrent.TimeUnit;
 import org.openjdk.jmh.Main;
@@ -11,8 +13,8 @@ import org.openjdk.jmh.annotations.*;
 @OutputTimeUnit(TimeUnit.MILLISECONDS)
 @State(Scope.Benchmark)
 @Fork(value = 1, jvmArgs = {"-Xms2G", "-Xmx2G"})
-@Warmup(iterations = 5)
-@Measurement(iterations = 5)
+@Warmup(iterations = 1)
+@Measurement(iterations = 1)
 public class BenchmarkRunner {
 
     private final org.yaml.snakeyaml.Yaml yaml = new org.yaml.snakeyaml.Yaml();
@@ -47,6 +49,17 @@ public class BenchmarkRunner {
         try (final Reader reader =
                  new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
             new YamlReader(reader).read();
+        }
+    }
+
+    @Benchmark
+    public void jacksonyaml() throws IOException {
+        try (final Reader reader =
+                 new FileReader(new File("target/test-classes/benchmark", "benchmark.yml"))) {
+            YAMLFactory.builder()
+                .build()
+                .createParser(reader)
+                .readValueAsTree();
         }
     }
 

--- a/src/test/resources/benchmark/benchmark.yml
+++ b/src/test/resources/benchmark/benchmark.yml
@@ -1,0 +1,2795 @@
+---
+run:
+  benchmarkName: benchmarks.ListVsArrayBenchmark
+  executedTimestamp: 2013-08-10T14:50:14UTC
+  measurements:
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArray
+          size: '3'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 7.832906054109315
+                processed: 7.832906054109315
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 8.120907845092502
+                processed: 8.120907845092502
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.782987165099336
+                processed: 7.782987165099336
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.926231194582875
+                processed: 7.926231194582875
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.916289764198039
+                processed: 7.916289764198039
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 8.401533548281853
+                processed: 8.401533548281853
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.702261410112022
+                processed: 7.702261410112022
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.810587328685924
+                processed: 7.810587328685924
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.903728704541201
+                processed: 7.903728704541201
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 7.917161472648377
+                processed: 7.917161472648377
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArray, size=3}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 115583278 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.83 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 63833269 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 8.12 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 191499807 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.78 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.93 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.92 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 8.40 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.70 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.81 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.90 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 127666538 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 7.92 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewArray
+          size: '3'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 27.379337460296576
+                processed: 27.379337460296576
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 28.852236667439495
+                processed: 28.852236667439495
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.924982694889458
+                processed: 27.924982694889458
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 28.081381740988014
+                processed: 28.081381740988014
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.854317911839246
+                processed: 27.854317911839246
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.554163215843392
+                processed: 27.554163215843392
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 28.0542968680803
+                processed: 28.0542968680803
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.9295457359926
+                processed: 27.9295457359926
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 28.546683208167323
+                processed: 28.546683208167323
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 29.282925754929792
+                processed: 29.282925754929792
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewArray, size=3}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 35298594 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.38 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 18261946 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 28.85 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 54785839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.92 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 28.08 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.85 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.55 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 28.05 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.93 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 28.55 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36523893 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 29.28 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewEmptyArray
+          size: '3'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 18.788686060707192
+                processed: 18.788686060707192
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 19.270630550953058
+                processed: 19.270630550953058
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.273942300621258
+                processed: 17.273942300621258
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.492441922150995
+                processed: 17.492441922150995
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 18.269697612440847
+                processed: 18.269697612440847
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.508784584499196
+                processed: 17.508784584499196
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.409702992393267
+                processed: 17.409702992393267
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.1962816100153
+                processed: 17.1962816100153
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.611907153301907
+                processed: 17.611907153301907
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 17.96338926781598
+                processed: 17.96338926781598
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewEmptyArray, size=3}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 52545076 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 18.79 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 26611759 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 19.27 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 79835279 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.27 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.49 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 18.27 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.51 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.41 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.20 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.61 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 53223519 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 17.96 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: NewList
+          size: '3'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 9.703475833866067
+                processed: 9.703475833866067
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.916187720883862
+                processed: 9.916187720883862
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.472249902645027
+                processed: 9.472249902645027
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.850417843799365
+                processed: 9.850417843799365
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.526581813328315
+                processed: 9.526581813328315
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.975872142344556
+                processed: 9.975872142344556
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.640343724284273
+                processed: 9.640343724284273
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.338418675969454
+                processed: 9.338418675969454
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.367025085571315
+                processed: 9.367025085571315
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 9.684311570652634
+                processed: 9.684311570652634
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=NewList, size=3}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 99155372 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.70 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 51527927 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.92 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 154583782 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.47 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.85 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.53 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.98 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.64 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.34 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.37 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 103055855 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 9.68 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: UnmodifiableWrapper
+          size: '3'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 0.6271404521257821
+                processed: 0.6271404521257821
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6565469188632224
+                processed: 0.6565469188632224
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6223859873704547
+                processed: 0.6223859873704547
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6161487591552033
+                processed: 0.6161487591552033
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6242652202961535
+                processed: 0.6242652202961535
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6198343532167311
+                processed: 0.6198343532167311
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6188504984108436
+                processed: 0.6188504984108436
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6233954573899128
+                processed: 0.6233954573899128
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6375467205212744
+                processed: 0.6375467205212744
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6236837814500212
+                processed: 0.6236837814500212
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=UnmodifiableWrapper, size=3}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 1588568466 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.63 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 797269572 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.66 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 2147483647 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.64 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1594539144 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArray
+          size: '30'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 27.4467865808024
+                processed: 27.4467865808024
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.301888152363485
+                processed: 27.301888152363485
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.183815486157798
+                processed: 27.183815486157798
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArray, size=30}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 35519471 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.45 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 18217068 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.30 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 54651206 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.18 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewArray
+          size: '30'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 65.35598902560038
+                processed: 65.35598902560038
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 70.25799617484454
+                processed: 70.25799617484454
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 67.94806926201409
+                processed: 67.94806926201409
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 65.1150449100231
+                processed: 65.1150449100231
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 63.20462490366527
+                processed: 63.20462490366527
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 63.685828781942085
+                processed: 63.685828781942085
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 62.8156847974644
+                processed: 62.8156847974644
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 66.57408670230399
+                processed: 66.57408670230399
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 64.48465055719905
+                processed: 64.48465055719905
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 64.7704159699718
+                processed: 64.7704159699718
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewArray, size=30}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 14846188 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 65.36 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 7650408 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 70.26 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 22951224 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 67.95 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 65.12 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 63.20 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 63.69 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 62.82 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 66.57 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 64.48 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 15300816 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 64.77 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewEmptyArray
+          size: '30'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 53.43935007090213
+                processed: 53.43935007090213
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 51.58175445879243
+                processed: 51.58175445879243
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 51.43560339066271
+                processed: 51.43560339066271
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 53.07903332702393
+                processed: 53.07903332702393
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 52.20448968572424
+                processed: 52.20448968572424
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 53.127279014655315
+                processed: 53.127279014655315
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 54.067658707659064
+                processed: 54.067658707659064
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 53.54545380216175
+                processed: 53.54545380216175
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 52.21167797318648
+                processed: 52.21167797318648
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 54.44177424631544
+                processed: 54.44177424631544
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewEmptyArray, size=30}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 18046707 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 53.44 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 9356401 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 51.58 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 28069203 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 51.44 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 53.08 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 52.20 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 53.13 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 54.07 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 53.55 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 52.21 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 18712802 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 54.44 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: NewList
+          size: '30'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 27.689452230342138
+                processed: 27.689452230342138
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.126285891276698
+                processed: 27.126285891276698
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.261475875139915
+                processed: 27.261475875139915
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 26.949162248699185
+                processed: 26.949162248699185
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.475950616969453
+                processed: 27.475950616969453
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.510403134889028
+                processed: 27.510403134889028
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.88453780835493
+                processed: 27.88453780835493
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.146034697375747
+                processed: 27.146034697375747
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.085958803356018
+                processed: 27.085958803356018
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 27.137567373629146
+                processed: 27.137567373629146
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=NewList, size=30}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 35427300 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.69 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 18057417 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.13 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 54172252 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.26 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 26.95 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.48 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.51 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.88 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.15 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.09 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 36114835 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 27.14 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: UnmodifiableWrapper
+          size: '30'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 0.6158303479416829
+                processed: 0.6158303479416829
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6508442413936283
+                processed: 0.6508442413936283
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6218615405363317
+                processed: 0.6218615405363317
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6184992262575103
+                processed: 0.6184992262575103
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6222152537323354
+                processed: 0.6222152537323354
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6216358811566874
+                processed: 0.6216358811566874
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.616605393979562
+                processed: 0.616605393979562
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6162987474160366
+                processed: 0.6162987474160366
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6184891371089176
+                processed: 0.6184891371089176
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6138798218493207
+                processed: 0.6138798218493207
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=UnmodifiableWrapper, size=30}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 1596739130 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 811911919 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.65 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 2147483647 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623823839 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.61 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArray
+          size: '300'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 239.58869988386775
+                processed: 239.58869988386775
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 235.73190589527383
+                processed: 235.73190589527383
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 237.79040875271875
+                processed: 237.79040875271875
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArray, size=300}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 4069498 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 239.59 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 2086909 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 235.73 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 6260729 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 237.79 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewArray
+          size: '300'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 529.4722583654205
+                processed: 529.4722583654205
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 582.2171589349554
+                processed: 582.2171589349554
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 518.510819767957
+                processed: 518.510819767957
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 525.7898498045982
+                processed: 525.7898498045982
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 520.3325181225125
+                processed: 520.3325181225125
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 518.0572592502779
+                processed: 518.0572592502779
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 518.892043778886
+                processed: 518.892043778886
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 519.929733733685
+                processed: 519.929733733685
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 517.0482058037575
+                processed: 517.0482058037575
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 523.5689942091617
+                processed: 523.5689942091617
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewArray, size=300}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 1886785 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 529.47 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 944336 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 582.22 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 2833009 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 518.51 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 525.79 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 520.33 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 518.06 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 518.89 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 519.93 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 517.05 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1888673 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 523.57 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: ToArrayWithNewEmptyArray
+          size: '300'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 375.6254268489594
+                processed: 375.6254268489594
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 383.4748815464953
+                processed: 383.4748815464953
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 379.36944722198643
+                processed: 379.36944722198643
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 370.71310099142596
+                processed: 370.71310099142596
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 376.60096851281594
+                processed: 376.60096851281594
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 392.48763365694725
+                processed: 392.48763365694725
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 378.26245743223905
+                processed: 378.26245743223905
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 383.08394328655794
+                processed: 383.08394328655794
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 386.3181957504735
+                processed: 386.3181957504735
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 376.2882306010083
+                processed: 376.2882306010083
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=ToArrayWithNewEmptyArray, size=300}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 2502056 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 375.63 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 1331113 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 383.47 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 3993339 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 379.37 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 370.71 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 376.60 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 392.49 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 378.26 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 383.08 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 386.32 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 2662226 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 376.29 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: NewList
+          size: '300'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 245.0469730717705
+                processed: 245.0469730717705
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 240.36261220088952
+                processed: 240.36261220088952
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 237.90886179758303
+                processed: 237.90886179758303
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 237.64297266500853
+                processed: 237.64297266500853
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 238.92836394378622
+                processed: 238.92836394378622
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 240.2394376171631
+                processed: 240.2394376171631
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 238.93769680336206
+                processed: 238.93769680336206
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 239.9377641912837
+                processed: 239.9377641912837
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=NewList, size=300}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 4068927 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 245.05 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 2040425 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 240.36 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 6121275 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 237.91 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 4080850 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 237.64 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 4080850 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 238.93 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 4080850 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 240.24 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 4080850 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 238.94 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 4080850 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 239.94 nanoseconds per rep]
+    - k:
+        variables:
+          vm: java
+          trial: '0'
+          benchmark: UnmodifiableWrapper
+          size: '300'
+      v:
+        measurementSetMap:
+          TIME:
+            measurements:
+              - raw: 0.615893991252921
+                processed: 0.615893991252921
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6576556818031484
+                processed: 0.6576556818031484
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6292615009608034
+                processed: 0.6292615009608034
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6187731758637912
+                processed: 0.6187731758637912
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6277042053637764
+                processed: 0.6277042053637764
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6199340608988009
+                processed: 0.6199340608988009
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6177035558481317
+                processed: 0.6177035558481317
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6194245595148191
+                processed: 0.6194245595148191
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6237064744182478
+                processed: 0.6237064744182478
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+              - raw: 0.6188901661592746
+                processed: 0.6188901661592746
+                unitNames:
+                  ns: 1
+                  s: 1000000000
+                  ms: 1000000
+                  us: 1000
+            unitNames:
+              ns: 1
+              s: 1000000000
+              ms: 1000000
+              us: 1000
+            systemOutCharCount: 0
+            systemErrCharCount: 0
+        eventLogMap:
+          TIME: |
+            starting Scenario{vm=java, trial=0, benchmark=UnmodifiableWrapper, size=300}
+            [caliper] [starting warmup]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [ending warmup]
+            [caliper] [measuring nanos per rep with scale 1.00]
+            [caliper] [running trial with 1595861895 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 0.50]
+            [caliper] [running trial with 811828020 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.66 nanoseconds per rep]
+            [caliper] [measuring nanos per rep with scale 1.50]
+            [caliper] [running trial with 2147483647 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.63 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.63 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+            [caliper] [performing additional measurement with scale 1.00]
+            [caliper] [running trial with 1623656041 reps]
+            [caliper] [starting measured section]
+            [caliper] [done measured section]
+            [caliper] [took 0.62 nanoseconds per rep]
+environment:
+  propertyMap:
+    jre.vmname: Java HotSpot(TM) 64-Bit Server VM
+    host.cpu.names: "[Intel(R) Core(TM) i5-3320M CPU @ 2.60GHz x 4]"
+    jre.version: 1.6.0_32-ea-b03
+    host.cpu.cores: "[2 x 4]"
+    jre.availableProcessors: '4'
+    os.name: Linux
+    jre.vmversion: 20.7-b02
+    host.memory.swap: "[6183932 kB]"
+    os.version: 3.5.0-25-generic
+    host.cpu.cachesize: "[3072 KB x 4]"
+    host.cpus: '4'
+    host.name: kelvin
+    os.arch: amd64
+    host.memory.physical: "[7871592 kB]"


### PR DESCRIPTION
```
Benchmark                    Mode  Cnt  Score   Error  Units
BenchmarkRunner.eoyaml       avgt    3  0,780 ± 0,089  ms/op
BenchmarkRunner.jacksonyaml  avgt    3  4,874 ± 0,702  ms/op
BenchmarkRunner.snakeyaml    avgt    3  9,532 ± 0,890  ms/op
BenchmarkRunner.yamlbeans    avgt    3  6,773 ± 0,598  ms/op
```
(low is better)
This result shows us eo-yaml is the fastest library, I guess.
I think It's about the features because eo-yaml has not so much feature so It's more simple and reliable(less error).
Fixes #377 