### PR TITLE
Fix coveralls.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ before_install: # Get the shell script for installing Early Access versions of t
   - wget https://github.com/sormuras/bach/raw/master/install-jdk.sh -O ~/install-ea-jdk.sh && chmod +x ~/install-ea-jdk.sh
 script:
   - set -e
-  - mvn clean install -Pcheckstyle,itcases -PtestCoverage jacoco:report coveralls:report
+  - mvn clean install -Pcheckstyle,itcases -PtestCoverage jacoco:report
 stages:
   - test # the default Travis stage.
   - testEarlyAccessJDK
@@ -30,4 +30,6 @@ jobs:
         - export JAVA_HOME=~/openjdk16
         - export PATH="$JAVA_HOME/bin:$PATH"
         - set -e
-        - mvn clean install -Pcheckstyle,itcases -PtestCoverage jacoco:report coveralls:report
+        - mvn clean install -Pcheckstyle,itcases -PtestCoverage jacoco:report
+after_success:
+  - mvn clean install -Pcheckstyle,itcases -PtestCoverage jacoco:report coveralls:report


### PR DESCRIPTION
I've noticed travis is failing https://travis-ci.org/github/decorators-squad/eo-yaml/jobs/729220848:
```
[ERROR] Failed to execute goal org.eluder.coveralls:coveralls-maven-plugin:4.3.0:report (default-cli) on project eo-yaml: Processing of input or output data failed: Report submission to Coveralls API failed with HTTP status 422: Unprocessable Entity (service_job_id (729220848) must be unique for Travis Jobs not supplying a Coveralls Repo Token) -> [Help 1]
```

AFAICT, people have been fixing it by putting the coveralls in the "after_success" part of the build:
https://github.com/operator-framework/operator-sdk/pull/3158/files
https://github.com/talesdsp/starwars-codex/commit/40d42fe4e3c4ce797c85219b51a48b4942207120