### PR TITLE
#418 Fix reading of Literal Scalars

### DIFF
--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -407,6 +407,35 @@ public final class ReadYamlMappingTest {
     }
 
     /**
+     * ReadYamlMapping returns a literal string mapped to a string key,
+     * by guessing the different lines' indentation (guessIndentation = true).
+     */
+    @Test
+    public void returnsLiteralStringWithStringKeyGuessIndentation(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("key: | ", 0));
+        lines.add(new RtYamlLine("  line1", 1));
+        lines.add(new RtYamlLine("    line2", 2));
+        final YamlMapping map = new ReadYamlMapping(
+            new AllYamlLines(lines), Boolean.TRUE
+        );
+        final Collection<String> literalLines = map.literalBlockScalar("key");
+        MatcherAssert.assertThat(
+            literalLines.size(),
+            Matchers.is(2)
+        );
+        final Iterator<String> linesIt = literalLines.iterator();
+        MatcherAssert.assertThat(
+            linesIt.next(),
+            Matchers.equalTo("line1")
+        );
+        MatcherAssert.assertThat(
+            linesIt.next(),
+            Matchers.equalTo("  line2")
+        );
+    }
+
+    /**
      * ReadYamlMapping can return the String mapped to a
      * String key.
      */


### PR DESCRIPTION
PR for #418 

The unit test with ``guessIndentation = true`` passes.
It should also work without guessing the indentation, but it doesn't, at the moment.
Let's try to fix it asap.