### PR TITLE
The possibility of comments before a scalar has been added.

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/BuiltComment.java
+++ b/src/main/java/com/amihaiemil/eoyaml/BuiltComment.java
@@ -46,13 +46,29 @@ class BuiltComment implements Comment {
     private final String value;
 
     /**
+     * The position of the comment.
+     */
+    private final boolean inlineComment;
+
+    /**
      * Constructor.
      * @param node Yaml node to which this comment refers.
      * @param value The String comment.
      */
     BuiltComment(final YamlNode node, final String value) {
+        this(node, value, false);
+    }
+
+    /**
+     * Constructor.
+     * @param node Yaml node to which this comment refers.
+     * @param value The String comment.
+     * @param inlineComment The position of the comment.
+     */
+    BuiltComment(final YamlNode node, final String value, final boolean inlineComment) {
         this.node = node;
         this.value = value;
+        this.inlineComment = inlineComment;
     }
 
     @Override
@@ -63,5 +79,10 @@ class BuiltComment implements Comment {
     @Override
     public String value() {
         return this.value;
+    }
+
+    @Override
+    public boolean inlineComment() {
+        return inlineComment;
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/Comment.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Comment.java
@@ -48,4 +48,11 @@ public interface Comment {
      *  will be added when printing.
      */
     String value();
+
+    /**
+     * The position of the comment.
+     * @return true - The comment should be placed after the node value;<br>
+     *     false - The comment should be placed before the node
+     */
+    boolean inlineComment();
 }

--- a/src/main/java/com/amihaiemil/eoyaml/JsonYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/JsonYamlMapping.java
@@ -52,6 +52,11 @@ final class JsonYamlMapping extends BaseYamlMapping {
             public String value() {
                 return "";
             }
+
+            @Override
+            public boolean inlineComment() {
+                return false;
+            }
         };
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/JsonYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/JsonYamlSequence.java
@@ -44,6 +44,11 @@ final class JsonYamlSequence extends BaseYamlSequence {
             public String value() {
                 return "";
             }
+
+            @Override
+            public boolean inlineComment() {
+                return false;
+            }
         };
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/PlainStringScalar.java
@@ -56,17 +56,18 @@ final class PlainStringScalar extends BaseScalar {
      * @param value Given value for this scalar.
      */
     PlainStringScalar(final String value) {
-        this(value, "");
+        this(value, "", true);
     }
 
     /**
      * Ctor.
      * @param comment Comment referring to this Scalar.
      * @param value Given value for this scalar.
+     * @param inlineComment Whether the comment is inline or before the scalar.
      */
-    PlainStringScalar(final String value, final String comment) {
+    PlainStringScalar(final String value, final String comment, final boolean inlineComment) {
         this.value = value;
-        this.comment = new BuiltComment(this, comment);
+        this.comment = new BuiltComment(this, comment, inlineComment);
     }
 
     /**

--- a/src/main/java/com/amihaiemil/eoyaml/ReadComment.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadComment.java
@@ -67,6 +67,15 @@ final class ReadComment implements Comment {
     }
 
     /**
+     * Always returns false as ReadComment doesn't save the position of the comment.
+     * @return false
+     */
+    @Override
+    public boolean inlineComment() {
+        return false;
+    }
+
+    /**
      * Pre-compute the comment value.
      *
      * @param lines The lines to parse into comments.

--- a/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlMapping.java
@@ -118,6 +118,11 @@ final class ReflectedYamlMapping extends BaseYamlMapping {
             public String value() {
                 return "";
             }
+
+            @Override
+            public boolean inlineComment() {
+                return false;
+            }
         };
     }
 
@@ -208,6 +213,11 @@ final class ReflectedYamlMapping extends BaseYamlMapping {
                 @Override
                 public String value() {
                     return "";
+                }
+
+                @Override
+                public boolean inlineComment() {
+                    return false;
                 }
             };
         }

--- a/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlScalar.java
@@ -71,6 +71,11 @@ final class ReflectedYamlScalar extends BaseScalar {
             public String value() {
                 return "";
             }
+
+            @Override
+            public boolean inlineComment() {
+                return true;
+            }
         };
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReflectedYamlSequence.java
@@ -84,6 +84,11 @@ final class ReflectedYamlSequence extends BaseYamlSequence {
             public String value() {
                 return "";
             }
+
+            @Override
+            public boolean inlineComment() {
+                return false;
+            }
         };
     }
 

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlScalarBuilder.java
@@ -30,6 +30,7 @@ package com.amihaiemil.eoyaml;
 import java.util.ArrayList;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Objects;
 import java.util.stream.Collectors;
 
 /**
@@ -71,20 +72,34 @@ final class RtYamlScalarBuilder implements YamlScalarBuilder {
 
     @Override
     public Scalar buildPlainScalar(final String comment) {
-        final String plain = this.lines.stream().filter(line -> line!=null).map(
-            line -> line.replaceAll(System.lineSeparator(), " ")
-        ).collect(Collectors.joining(" "));
-        return new PlainStringScalar(plain, comment);
+        return buildPlainScalar(comment, !comment.contains(System.lineSeparator()));
+    }
+
+    @Override
+    public Scalar buildPlainScalar(final String comment, boolean inlineComment) {
+        final String plain = this.lines.stream().filter(Objects::nonNull)
+                .collect(Collectors.joining(" "));
+        return new PlainStringScalar(plain, comment, inlineComment);
     }
 
     @Override
     public Scalar buildFoldedBlockScalar(final String comment) {
-        return new BuiltFoldedBlockScalar(this.lines, comment);
+        return buildFoldedBlockScalar(comment, !comment.contains(System.lineSeparator()));
+    }
+
+    @Override
+    public Scalar buildFoldedBlockScalar(final String comment, boolean inlineComment) {
+        return new BuiltFoldedBlockScalar(this.lines, comment, inlineComment);
     }
 
     @Override
     public Scalar buildLiteralBlockScalar(final String comment) {
-        return new BuiltLiteralBlockScalar(this.lines, comment);
+        return buildLiteralBlockScalar(comment, !comment.contains(System.lineSeparator()));
+    }
+
+    @Override
+    public Scalar buildLiteralBlockScalar(final String comment, boolean inlineComment) {
+        return new BuiltLiteralBlockScalar(this.lines, comment, inlineComment);
     }
 
     /**
@@ -110,7 +125,7 @@ final class RtYamlScalarBuilder implements YamlScalarBuilder {
          * @param lines Given string lines.
          */
         BuiltFoldedBlockScalar(final List<String> lines) {
-            this(lines, "");
+            this(lines, "", true);
         }
 
         /**
@@ -119,10 +134,10 @@ final class RtYamlScalarBuilder implements YamlScalarBuilder {
          * @param lines Given string lines.
          */
         BuiltFoldedBlockScalar(
-            final List<String> lines, final String comment
+            final List<String> lines, final String comment, final boolean inlineComment
         ) {
             this.lines = lines;
-            this.comment = new BuiltComment(this, comment);
+            this.comment = new BuiltComment(this, comment, inlineComment);
         }
 
         /**
@@ -177,19 +192,20 @@ final class RtYamlScalarBuilder implements YamlScalarBuilder {
          * @param lines Given string lines.
          */
         BuiltLiteralBlockScalar(final List<String> lines) {
-            this(lines, "");
+            this(lines, "", true);
         }
 
         /**
          * Ctor.
          * @param lines Given string lines.
          * @param comment Comment referring to this scalar.
+         * @param inlineComment The position of the comment.
          */
         BuiltLiteralBlockScalar(
-            final List<String> lines, final String comment
+            final List<String> lines, final String comment, boolean inlineComment
         ) {
             this.lines = lines;
-            this.comment = new BuiltComment(this, comment);
+            this.comment = new BuiltComment(this, comment, inlineComment);
         }
 
 

--- a/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlScalarBuilder.java
@@ -96,6 +96,18 @@ public interface YamlScalarBuilder {
     Scalar buildPlainScalar(final String comment);
 
     /**
+     * Build a plain Scalar. Ideally, you should use this when
+     * your scalar is short, a single line of text.<br><br>
+     * If you added more lines of text, all of them will be put together,
+     * separated by spaces.
+     * @param comment Comment referring to the built scalar.
+     * @param inlineComment Whether the comment is placed inline after the value
+     *                      or before the scalar.
+     * @return The built Scalar.
+     */
+    Scalar buildPlainScalar(final String comment, final boolean inlineComment);
+
+    /**
      * Build a Folded Block Scalar. Use this when your scalar has multiple
      * lines of text, but you don't care about the newlines, you want them
      * all separated by spaces. <br><br>
@@ -114,11 +126,41 @@ public interface YamlScalarBuilder {
     Scalar buildFoldedBlockScalar(final String comment);
 
     /**
+     * Build a Folded Block Scalar. Use this when your scalar has multiple
+     * lines of text, but you don't care about the newlines, you want them
+     * all separated by spaces. <br><br>
+     *
+     * The difference from buildPlainScalar() comes when you are printing
+     * the created YAML:
+     * <pre>
+     *     plain: a very long scalar which should have been built as Folded
+     *     folded:&gt;
+     *       a very long scalar which
+     *       has been folded for readability
+     * </pre>
+     * @param comment Comment referring to the built scalar.
+     * @param inlineComment Whether the comment is placed inline after the value
+     *                      or before the scalar.
+     * @return The built Scalar.
+     */
+    Scalar buildFoldedBlockScalar(final String comment, boolean inlineComment);
+
+    /**
      * Build a Literal Block Scalar. Use this when your scalar has multiple
      * lines and you want these lines to be separated.
      * @param comment Comment referring to the built scalar.
      * @return The built Scalar.
      */
     Scalar buildLiteralBlockScalar(final String comment);
+
+    /**
+     * Build a Literal Block Scalar. Use this when your scalar has multiple
+     * lines and you want these lines to be separated.
+     * @param comment Comment referring to the built scalar.
+     * @param inlineComment Whether the comment is placed inline after the value
+     *                      or before the scalar.
+     * @return The built Scalar.
+     */
+    Scalar buildLiteralBlockScalar(final String comment, boolean inlineComment);
 
 }

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltFoldedBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltFoldedBlockScalarTest.java
@@ -79,7 +79,7 @@ public final class BuiltFoldedBlockScalarTest {
     @Test
     public void returnsComment() {
         final Scalar scl = new RtYamlScalarBuilder.BuiltFoldedBlockScalar(
-            new ArrayList<>(), "comment"
+            new ArrayList<>(), "comment", true
         );
         MatcherAssert.assertThat(
             scl.comment().value(),

--- a/src/test/java/com/amihaiemil/eoyaml/BuiltLiteralBlockScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/BuiltLiteralBlockScalarTest.java
@@ -79,7 +79,7 @@ public final class BuiltLiteralBlockScalarTest {
     @Test
     public void returnsComment() {
         final Scalar scl = new RtYamlScalarBuilder.BuiltLiteralBlockScalar(
-            new ArrayList<>(), "comment"
+            new ArrayList<>(), "comment", true
         );
         MatcherAssert.assertThat(
             scl.comment().value(),

--- a/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/PlainStringScalarTest.java
@@ -61,7 +61,7 @@ public final class PlainStringScalarTest {
     @Test
     public void returnsComment() {
         final String val = "test scalar value";
-        final PlainStringScalar scl = new PlainStringScalar(val, "comment");
+        final PlainStringScalar scl = new PlainStringScalar(val, "comment", true);
         MatcherAssert.assertThat(
             scl.comment().value(),
             Matchers.equalTo("comment")


### PR DESCRIPTION
Fix of issue #452.
See the git commit message

> When building a scalar via a ScalarBuilder, for each type of scalar there is a method to build which receives the boolean inlineComment which determines whether the comment is written inline after the value or before the scalar.
> If no inlineComment value is explicitely defined, the method building the scalar checks whether the comment contains a line break. If that's the case, a multiline comment before the scalar is used, if not, an inline comment is used.
> If it is explicitely defined that an inline comment should be used which contains line breaks, those are transformed to spaces. Therefore, the previous bug that parts of a comment with line breaks are printed not as comments but as values after the scalar is resolved.
> The printer uses this information which is now saved in the comment to print the nodes. Therefore the comments of scalars are printed at the set place now.

In my variety of tests, my changes worked exactly as I expected it. I also tried to keep the code and documentation style the same.

Summarising:
- The commit added the possibility of comments before a scalar 
- The commit fixed the bug that multiline scalar inline commits wrote onto the next lines uncommented (now the line breaks get replaced with spaces)
- Comments now generally save a value whether they're inline or not which means that in the future inline comments for other types could be added with few changes

Beware:
The subclass ReadComment right now returns `inlineComment()` with false.
I am also not so sure if the comments of scalars are read correctly. The ability to print them correctly was what I've focused on for now and the optimal behaviour might be that while reading Yaml, the ReadComments save whether they are inline or not. However, that still needs to get implemented.