### PR TITLE
#454 read comments above scalar if inline comment missing

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadPlainScalar.java
@@ -135,13 +135,35 @@ final class ReadPlainScalar extends BaseScalar {
         if(this.scalar instanceof YamlLine.NullYamlLine) {
             comment = new BuiltComment(this, "");
         } else {
-            comment = new ReadComment(
+            final Comment inline = new ReadComment(
                     new Skip(
                         this.all,
                         line -> line.number() != this.scalar.number()
                     ),
                 this
             );
+            if(inline.value().trim().isEmpty()) {
+                final int lineNumber = this.scalar.number();
+                comment = new ReadComment(
+                    new Backwards(
+                        new FirstCommentFound(
+                            new Backwards(
+                                new Skip(
+                                    this.all,
+                                    line -> line.number() >= lineNumber,
+                                    line -> line.trimmed().startsWith("..."),
+                                    line -> line.trimmed().startsWith("%"),
+                                    line -> line.trimmed().startsWith("!!")
+                                )
+                            ),
+                            false
+                        )
+                    ),
+                    this
+                );
+            } else {
+                comment = inline;
+            }
         }
         return comment;
     }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlMappingCommentsPrintTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlMappingCommentsPrintTest.java
@@ -44,6 +44,9 @@ import java.io.IOException;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 4.2.0
+ * @todo #454:60min Modify the printing logic for scalar comments: if the
+ *  comment contains line breaks, write it above the scalar. If the comment has
+ *  no line breaks, write it inline, after the scalar.
  */
 public final class YamlMappingCommentsPrintTest {
 

--- a/src/test/java/com/amihaiemil/eoyaml/YamlMappingCommentsPrintTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlMappingCommentsPrintTest.java
@@ -196,6 +196,45 @@ public final class YamlMappingCommentsPrintTest {
     }
 
     /**
+     * Reads scalar comments from a mapping properly.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsScalarComments() throws IOException {
+        final YamlMapping read = Yaml.createYamlInput(
+            new File(
+                "src/test/resources/scalarCommentsInMapping.yml"
+            )
+        ).readYamlMapping();
+        MatcherAssert.assertThat(
+            read.value("architect").comment().value(),
+            Matchers.equalTo(
+                "Mihai is the architect,\nhe has 8 years Java XP"
+            )
+        );
+        MatcherAssert.assertThat(
+            read.value("name").comment().value(),
+            Matchers.equalTo(
+                "name of the project"
+            )
+        );
+        MatcherAssert.assertThat(
+            read.value("provider").comment().value(),
+            Matchers.equalTo(
+                "git web service"
+            )
+        );
+        MatcherAssert.assertThat(
+            read.value("devops").comment().value(),
+            Matchers.equalTo("")
+        );
+        MatcherAssert.assertThat(
+            read.value("tech").comment().value(),
+            Matchers.equalTo("planet java")
+        );
+    }
+
+    /**
      * Read a test resource file's contents.
      * @param fileName File to read.
      * @return File's contents as String.

--- a/src/test/java/com/amihaiemil/eoyaml/YamlSequenceCommentsPrintTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlSequenceCommentsPrintTest.java
@@ -159,6 +159,50 @@ public final class YamlSequenceCommentsPrintTest {
     }
 
     /**
+     * Reads scalar comments from a sequence properly.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void readsScalarComments() throws IOException {
+        final YamlSequence read = Yaml.createYamlInput(
+            new File(
+                "src/test/resources/scalarCommentsInSequence.yml"
+            )
+        ).readYamlSequence();
+        final Iterator<YamlNode> values = read.values().iterator();
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.isEmptyString()
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.equalTo("a plain scalar string in a sequence")
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.isEmptyString()
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.equalTo("a mapping as an element of a sequence")
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.equalTo(
+                "comment on top of scalar in sequence\nit's multiline"
+            )
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.isEmptyString()
+        );
+        MatcherAssert.assertThat(
+            values.next().comment().value(),
+            Matchers.equalTo("inline comment about element6")
+        );
+    }
+
+    /**
      * Read a test resource file's contents.
      * @param fileName File to read.
      * @return File's contents as String.

--- a/src/test/resources/scalarCommentsInMapping.yml
+++ b/src/test/resources/scalarCommentsInMapping.yml
@@ -1,0 +1,14 @@
+# Mihai is the architect,
+# he has 8 years Java XP
+architect: mihai
+developers:
+  - rultor
+  - salikjan
+  - sherif
+name: "eo-yaml" # name of the project
+# git web service
+provider: github
+devops: rultor
+# this comment is ignored because the scalar has
+# an inline comment (closer to it)
+tech: java # planet java

--- a/src/test/resources/scalarCommentsInSequence.yml
+++ b/src/test/resources/scalarCommentsInSequence.yml
@@ -1,0 +1,14 @@
+- element1
+- element2 # a plain scalar string in a sequence
+- element3
+# a mapping as an element of a sequence
+-
+  key: value
+  key2: value2
+# comment on top of scalar in sequence
+# it's multiline
+- element4
+- element5
+# this comment is ignored because there is
+# an inline (closer comment)
+- element6 # inline comment about element6


### PR DESCRIPTION
Closes #454 

If a scalar has no inline comment, try to read it from above it.
If the scalar does have an inline comment, read that one and ignore the one above it.
Added tests.
Left puzzle for modifying the printing logic of scalar comments.