### PR TITLE
Added convenience methods for java primitive types

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/Scalar.java
+++ b/src/main/java/com/amihaiemil/eoyaml/Scalar.java
@@ -27,23 +27,331 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
+
 /**
  * Yaml Scalar.
+ * 
+ * @checkstyle ReturnCount (100 lines)
+ * 
  * @author Mihai Andronache (amihaiemil@gmail.com)
+ * 
  * @version $Id$
+ * 
  * @since 3.1.3
  */
 public interface Scalar extends YamlNode {
-
+    
     /**
-     * Value of this scalar. The value returned by this
-     * method should be un-escaped. e.g. if the scalar is
-     * escaped, say '#404040', the returned value should be
-     * #404040.
+     * Value of this scalar. The value returned by this method should be
+     * un-escaped. e.g. if the scalar is escaped, say '#404040', the returned
+     * value should be #404040.
+     * 
      * @return String value.
-     * @throws IllegalStateException In the case of reading YAML,
-     *  this exception is thrown if the Scalar isn't found where it's
-     *  supposed to be.
+     * 
+     * @throws IllegalStateException In the case of reading YAML, this exception
+     * is thrown if the Scalar isn't found where it's supposed to be.
      */
     String value();
+    
+    /**
+     * Convenience method to directly read the char value of this scalar.
+     * 
+     * @return The char value of this scalar.
+     * 
+     * @since 6.0.2
+     */
+    default char charValue() {
+        if (isEmpty()) {
+            return (char) 0;
+        }
+        return value().charAt(0);
+    }
+    
+    /**
+     * Convenience method to directly read the boolean value of this scalar.
+     * 
+     * @return The boolean value of this scalar.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue() {
+        return Boolean.valueOf(value());
+    }
+    
+    /**
+     * Convenience method to directly read the boolean value of this scalar.
+     * 
+     * @param trueValue The value to compare {@link #value()} with.
+     * 
+     * @return True if the value of this scalar is equal to the given trueValue.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue(String trueValue) {
+        return value().equalsIgnoreCase(trueValue);
+    }
+    
+    /**
+     * Convenience method to directly read the BigDecimal value of this scalar.
+     * 
+     * @param mathContext The math context to use.
+     * 
+     * @return The BigDecimal value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigDecimal#BigDecimal(String, MathContext)
+     */
+    default BigDecimal bigDecimalValue(MathContext mathContext) {
+        return new BigDecimal(value(), mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read the BigDecimal value of this scalar.
+     * 
+     * @return The BigDecimal value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigDecimal#BigDecimal(String)
+     */
+    default BigDecimal bigDecimalValue() {
+        return new BigDecimal(value());
+    }
+    
+    /**
+     * Convenience method to directly read the double value of this scalar.
+     * 
+     * @param mathContext The math context to use.
+     * 
+     * @return The double value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigDecimal#doubleValue()
+     */
+    default double doubleValue(MathContext mathContext) {
+        return bigDecimalValue(mathContext).doubleValue();
+    }
+    
+    /**
+     * Convenience method to directly read the double value of this scalar.
+     * 
+     * @return The double value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * double.
+     * 
+     * @since 6.0.2
+     */
+    default double doubleValue() {
+        return Double.parseDouble(value());
+    }
+    
+    /**
+     * Convenience method to directly read the float value of this scalar.
+     * 
+     * @param mathContext The math context to use.
+     * 
+     * @return The float value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigDecimal#floatValue()
+     */
+    
+    default float floatValue(MathContext mathContext) {
+        return bigDecimalValue(mathContext).floatValue();
+    }
+    
+    /**
+     * Convenience method to directly read the float value of this scalar.
+     * 
+     * @return The float value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * float.
+     * 
+     * @since 6.0.2
+     */
+    default float floatValue() {
+        return Float.parseFloat(value());
+    }
+    
+    /**
+     * Convenience method to directly read the BigInteger value of this scalar.
+     * 
+     * @param radix Radix to be used in interpreting {@link #value()}.
+     * 
+     * @return The BigInteger value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigInteger#BigInteger(String, int)
+     */
+    default BigInteger bigIntegerValue(int radix) {
+        return new BigInteger(value(), radix);
+    }
+    
+    /**
+     * Convenience method to directly read the BigInteger value of this scalar.
+     * 
+     * @return The BigInteger value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see BigInteger#BigInteger(String)
+     */
+    default BigInteger bigIntegerValue() {
+        return new BigInteger(value());
+    }
+    
+    /**
+     * Convenience method to directly read the long value of this scalar.
+     * 
+     * @param radix Radix to be used in interpreting {@link #value()}.
+     * 
+     * @return The long value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see #bigIntegerValue(int)
+     */
+    default long longValue(int radix) {
+        return bigIntegerValue(radix).longValue();
+    }
+    
+    /**
+     * Convenience method to directly read the long value of this scalar.
+     * 
+     * @return The long value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * long.
+     * 
+     * @since 6.0.2
+     */
+    default long longValue() {
+        return Long.parseLong(value());
+    }
+    
+    /**
+     * Convenience method to directly read the int value of this scalar.
+     * 
+     * @param radix Radix to be used in interpreting {@link #value()}.
+     * 
+     * @return The int value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see #bigIntegerValue(int)
+     */
+    default int intValue(int radix) {
+        return bigIntegerValue(radix).intValue();
+    }
+    
+    /**
+     * Convenience method to directly read the int value of this scalar.
+     * 
+     * @return The int value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * int.
+     * 
+     * @since 6.0.2
+     */
+    default int intValue() {
+        return Integer.parseInt(value());
+    }
+    
+    /**
+     * Convenience method to directly read the short value of this scalar.
+     * 
+     * @param radix Radix to be used in interpreting {@link #value()}.
+     * 
+     * @return The short value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see #bigIntegerValue(int)
+     */
+    default short shortValue(int radix) {
+        return bigIntegerValue(radix).shortValue();
+    }
+    
+    /**
+     * Convenience method to directly read the short value of this scalar.
+     * 
+     * @return The short value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * short.
+     * 
+     * @since 6.0.2
+     */
+    default short shortValue() {
+        return Short.parseShort(value());
+    }
+    
+    /**
+     * Convenience method to directly read the byte value of this scalar.
+     * 
+     * @param radix Radix to be used in interpreting {@link #value()}.
+     * 
+     * @return The byte value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     * 
+     * @see #bigIntegerValue(int)
+     */
+    default byte byteValue(int radix) {
+        return bigIntegerValue(radix).byteValue();
+    }
+    
+    /**
+     * Convenience method to directly read the byte value of this scalar.
+     * 
+     * @return The byte value of this scalar.
+     * 
+     * @throws NumberFormatException If the {@link #value()} is not a parsable
+     * byte.
+     * 
+     * @since 6.0.2
+     */
+    default byte byteValue() {
+        return Byte.parseByte(value());
+    }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlMapping.java
@@ -27,438 +27,1313 @@
  */
 package com.amihaiemil.eoyaml;
 
+import java.math.BigDecimal;
+import java.math.BigInteger;
+import java.math.MathContext;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeParseException;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Set;
 
 /**
  * A Yaml mapping.
+ * 
  * @checkstyle ExecutableStatementCount (300 lines)
- * @checkstyle ReturnCount (1000 lines)
+ * @checkstyle ReturnCount (1500 lines)
+ * 
  * @author Mihai Andronache (amihaiemil@gmail.com)
+ * 
  * @version $Id$
+ * 
  * @since 1.0.0
  */
 public interface YamlMapping extends YamlNode {
-
+    
     /**
-     * Return the keys' set of this mapping.<br><br>
+     * Return the keys' set of this mapping.<br>
+     * <br>
+     * 
      * @return Set of YamlNode keys.
      */
     Set<YamlNode> keys();
-
+    
     /**
      * Get the YamlNode mapped to the specified key.
-     * @param key YamlNode key. Could be a simple scalar,
-     *  a YamlMapping or a YamlSequence.
+     * 
+     * @param key YamlNode key. Could be a simple scalar, a YamlMapping or a
+     * YamlSequence.
+     * 
      * @return The found YamlNode or null if nothing is found.
      */
-    YamlNode value(final YamlNode key);
-
-    /**
-     * Fetch the values of this mapping.
-     * @return Collection of {@link YamlNode}
-     */
-    default Collection<YamlNode> values() {
-        final List<YamlNode> values = new LinkedList<>();
-        for(final YamlNode key : this.keys()) {
-            values.add(this.value(key));
-        }
-        return values;
-    }
-    /**
-     * Get the Yaml mapping associated with the given key.
-     * @param key String key
-     * @return Yaml mapping or null if the key is missing, or not pointing
-     *  to a mapping.
-     */
-    default YamlMapping yamlMapping(final String key) {
-        return this.yamlMapping(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Get the Yaml mapping associated with the given key.
-     * @param key Yaml node (mapping or sequence) key
-     * @return Yaml mapping or null if the key is missing, or not pointing
-     *  to a mapping.
-     */
-    default YamlMapping yamlMapping(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        final YamlMapping found;
-        if (value instanceof YamlMapping) {
-            found = (YamlMapping) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    /**
-     * Get the Yaml sequence associated with the given key.
-     * @param key String key
-     * @return Yaml sequence or null if the key is missing, or not pointing
-     *  to a sequence.
-     */
-    default YamlSequence yamlSequence(final String key) {
-        return this.yamlSequence(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Get the Yaml sequence associated with the given key.
-     * @param key Yaml node (mapping or sequence) key
-     * @return Yaml sequence or null if the key is missing, or not pointing
-     *  to a sequence
-     */
-    default YamlSequence yamlSequence(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        final YamlSequence found;
-        if (value instanceof YamlSequence) {
-            found =  (YamlSequence) value;
-        } else {
-            found = null;
-        }
-        return found;
-    }
-
-    /**
-     * Get the String associated with the given key.
-     * @param key String key
-     * @return String or null if the key is missing, or not pointing
-     *  to a scalar.
-     */
-    default String string(final String key) {
-        return this.string(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Get the String associated with the given key.
-     * @param key Yaml node key
-     * @return String or null if the key is missing, or not pointing
-     *  to a scalar.
-     */
-    default String string(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        final String found;
-        if (value instanceof Scalar) {
-            found = ((Scalar) value).value();
-        } else {
-            found = null;
-        }
-        return found;
-    }
-    /**
-     * Get the String folded block scalar associated with the given key.
-     * @param key String key
-     * @return String or null if the key is missing, or not pointing
-     *  to a folded block scalar.
-     */
-    default String foldedBlockScalar(final String key) {
-        return this.foldedBlockScalar(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Get the String folded block scalar associated with the given key.
-     * @param key Yaml node key.
-     * @return String or null if the key is missing, or not pointing
-     *  to a folded block scalar.
-     */
-    default String foldedBlockScalar(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        final String found;
-        if (value instanceof Scalar) {
-            found = ((Scalar) value).value();
-        } else {
-            found = null;
-        }
-        return found;
-    }
-    /**
-     * Get the String lines of the literal block scalar associated
-     * with the given key.
-     * @param key String key
-     * @return Collection of String or null if the key is missing,
-     *  or not pointing to a literal block scalar.
-     */
-    default Collection<String> literalBlockScalar(final String key) {
-        return this.literalBlockScalar(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Get the String lines of the literal block scalar associated
-     * with the given key.
-     * @param key String key
-     * @return Collection of String or null if the key is missing,
-     *  or not pointing to a literal block scalar.
-     */
-    default Collection<String> literalBlockScalar(final YamlNode key) {
-        final Collection<String> found;
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            found = Arrays.asList(
-                ((Scalar) value)
-                    .value()
-                    .split(System.lineSeparator())
-            );
-        } else {
-            found = null;
-        }
-        return found;
-    }
+    YamlNode value(YamlNode key);
+    
     /**
      * Get the YamlNode mapped to the specified key.
+     * 
      * @param key String key.
+     * 
      * @return The found YamlNode or null if nothing is found.
      */
     default YamlNode value(final String key) {
-        return this.value(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+        return value(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
     }
-
+    
     /**
-     * Convenience method to directly read an integer value
-     * from this map. It is equivalent to:
-     * <pre>
-     *     YamlMapping map = ...;
-     *     int value = Integer.parseInt(map.string(...));
-     * </pre>
-     * @param key The key of the value.
-     * @return Found integer or -1 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable integer.
+     * Fetch the values of this mapping.
+     * 
+     * @return Collection of {@link YamlNode}
      */
-    default int integer(final String key) {
-        return this.integer(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
-    }
-
-    /**
-     * Convenience method to directly read an integer value
-     * from this map. It is equivalent to:
-     * <pre>
-     *     YamlMapping map = ...;
-     *     int value = Integer.parseInt(map.string(...));
-     * </pre>
-     * @param key The key of the value.
-     * @return Found integer or -1 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable integer.
-     */
-    default int integer(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return Integer.parseInt(((Scalar) value).value());
+    default Collection<YamlNode> values() {
+        List<YamlNode> values = new ArrayList<>();
+        
+        for (final YamlNode key : keys()) {
+            values.add(value(key));
         }
-        return -1;
+        return values;
     }
-
+    
     /**
-     * Convenience method to directly read a float value
-     * from this map. It is equivalent to:
-     * <pre>
-     *     YamlMapping map = ...;
-     *     float value = Float.parseFloat(map.string(...));
-     * </pre>
-     * @param key The key of the value.
-     * @return Found float or -1 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable float.
+     * Get the Yaml mapping associated with the given key.
+     * 
+     * @param key String key.
+     * 
+     * @return Yaml mapping or null if the key is missing, or not pointing to a
+     * mapping.
      */
-    default float floatNumber(final String key) {
-        return this.floatNumber(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+    default YamlMapping yamlMapping(String key) {
+        return yamlMapping(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
     }
-
+    
     /**
-     * Convenience method to directly read a float value
-     * from this map. It is equivalent to:
+     * Get the Yaml mapping associated with the given key.
+     * 
+     * @param key Yaml node (mapping or sequence) key.
+     * 
+     * @return Yaml mapping or null if the key is missing, or not pointing to a
+     * mapping.
+     */
+    default YamlMapping yamlMapping(YamlNode key) {
+        YamlNode value = value(key);
+        
+        if (value instanceof YamlMapping) {
+            return (YamlMapping) value;
+        }
+        return null;
+    }
+    
+    /**
+     * Get the Yaml sequence associated with the given key.
+     * 
+     * @param key String key.
+     * 
+     * @return Yaml sequence or null if the key is missing, or not pointing to a
+     * sequence.
+     */
+    default YamlSequence yamlSequence(String key) {
+        return yamlSequence(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Get the Yaml sequence associated with the given key.
+     * 
+     * @param key Yaml node (mapping or sequence) key.
+     * 
+     * @return Yaml sequence or null if the key is missing, or not pointing to a
+     * sequence.
+     */
+    default YamlSequence yamlSequence(YamlNode key) {
+        YamlNode value = value(key);
+        
+        if (value instanceof YamlSequence) {
+            return (YamlSequence) value;
+        }
+        return null;
+    }
+    
+    /**
+     * Get the Yaml scalar associated with the given key.
+     * 
+     * @param key String key.
+     * 
+     * @return Yaml scalar or null if the key is missing, or not pointing to a
+     * scalar.
+     * 
+     * @see 6.0.2
+     */
+    default Scalar yamlScalar(String key) {
+        return yamlScalar(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Get the Yaml scalar associated with the given key.
+     * 
+     * @param key Yaml node (mapping or sequence) key.
+     * 
+     * @return Yaml scalar or null if the key is missing, or not pointing to a
+     * scalar.
+     * 
+     * @see 6.0.2
+     */
+    default Scalar yamlScalar(YamlNode key) {
+        YamlNode value = value(key);
+        
+        if (value instanceof Scalar) {
+            return (Scalar) value;
+        }
+        return null;
+    }
+    
+    /**
+     * Get the String associated with the given key.
+     * 
+     * @param key String key
+     * 
+     * @return String or null if the key is missing, or not pointing to a
+     * scalar.
+     */
+    default String string(String key) {
+        return string(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Get the String associated with the given key.
+     * 
+     * @param key Yaml node key
+     * 
+     * @return String or null if the key is missing, or not pointing to a
+     * scalar.
+     */
+    default String string(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return null;
+        }
+        return value.value();
+    }
+    
+    /**
+     * Get the String folded block scalar associated with the given key.
+     * 
+     * @param key String key
+     * 
+     * @return String or null if the key is missing, or not pointing to a folded
+     * block scalar.
+     */
+    default String foldedBlockScalar(String key) {
+        return string(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Get the String folded block scalar associated with the given key.
+     * 
+     * @param key Yaml node key.
+     * 
+     * @return String or null if the key is missing, or not pointing to a folded
+     * block scalar.
+     */
+    default String foldedBlockScalar(YamlNode key) {
+        return string(key);
+    }
+    
+    /**
+     * Get the String lines of the literal block scalar associated with the
+     * given key.
+     * 
+     * @param key String key
+     * 
+     * @return Collection of String or null if the key is missing, or not
+     * pointing to a literal block scalar.
+     */
+    default Collection<String> literalBlockScalar(String key) {
+        return literalBlockScalar(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Get the String lines of the literal block scalar associated with the
+     * given key.
+     * 
+     * @param key String key
+     * 
+     * @return Collection of String or null if the key is missing, or not
+     * pointing to a literal block scalar.
+     */
+    default Collection<String> literalBlockScalar(YamlNode key) {
+        String value = string(key);
+        
+        if (value == null) {
+            return null;
+        }
+        return Arrays.asList(value.split(System.lineSeparator()));
+    }
+    
+    /**
+     * Convenience method to directly read a boolean value from this map. It is
+     * equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
-     *     float value = Float.parseFloat(map.string(...));
+     *     Scalar scalar = map.yamlScalar(...);
+     *     boolean value = scalar.booleanValue();
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found float or -1 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable float.
+     * 
+     * @return Found boolean or <code>false</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue(String key) {
+        return booleanValue(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a boolean value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     boolean value = scalar.booleanValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found boolean or <code>false</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return false;
+        }
+        return value.booleanValue();
+    }
+    
+    /**
+     * Convenience method to directly read a boolean value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     boolean value = scalar.booleanValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param trueValue The value to compare the Scalar value with.
+     * 
+     * @return Found boolean or <code>false</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue(String key, String trueValue) {
+        return booleanValue(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                trueValue);
+    }
+    
+    /**
+     * Convenience method to directly read a boolean value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     boolean value = scalar.booleanValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param trueValue The value to compare the Scalar value with.
+     * 
+     * @return Found boolean or <code>false</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @since 6.0.2
+     */
+    default boolean booleanValue(YamlNode key, String trueValue) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return false;
+        }
+        return value.booleanValue(trueValue);
+    }
+    
+    /**
+     * Convenience method to directly read a BigDecimal value from this map. It
+     * is equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigDecimal value = scalar.bigDecimalValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found BigDecimal or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default BigDecimal bigDecimalNumber(String key, MathContext mathContext) {
+        return bigDecimalNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a BigDecimal value from this map. It
+     * is equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigDecimal value = scalar.bigDecimalValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found BigDecimal or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default BigDecimal bigDecimalNumber(YamlNode key, MathContext mathContext) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return null;
+        }
+        return value.bigDecimalValue(mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a BigDecimal value from this map. It
+     * is equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigDecimal value = scalar.bigDecimalValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found BigDecimal or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default BigDecimal bigDecimalNumber(String key) {
+        return bigDecimalNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a BigDecimal value from this map. It
+     * is equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigDecimal value = scalar.bigDecimalValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found BigDecimal or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default BigDecimal bigDecimalNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return null;
+        }
+        return value.bigDecimalValue();
+    }
+    
+    /**
+     * Convenience method to directly read a double value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     double value = scalar.doubleValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found double or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default double doubleNumber(String key, MathContext mathContext) {
+        return doubleNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a double value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     double value = scalar.doubleValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found double or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default double doubleNumber(YamlNode key, MathContext mathContext) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.doubleValue(mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a double value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     double value = scalar.doubleValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found double or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * double.
+     */
+    default double doubleNumber(String key) {
+        return doubleNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a double value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     double value = scalar.doubleValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found double or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * double.
+     */
+    default double doubleNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.doubleValue();
+    }
+    
+    /**
+     * Convenience method to directly read a float value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     float value = scalar.floatValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found float or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default float floatNumber(String key, MathContext mathContext) {
+        return floatNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a float value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     float value = scalar.floatValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param mathContext The math context to use.
+     * 
+     * @return Found float or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default float floatNumber(YamlNode key, MathContext mathContext) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.floatValue(mathContext);
+    }
+    
+    /**
+     * Convenience method to directly read a float value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     float value = scalar.floatValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found float or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * float.
+     */
+    default float floatNumber(String key) {
+        return floatNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a float value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     float value = scalar.floatValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found float or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * float.
      */
     default float floatNumber(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return Float.parseFloat(((Scalar) value).value());
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
         }
-        return -1;
+        return value.floatValue();
     }
-
+    
     /**
-     * Convenience method to directly read a double value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a BigInteger value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
-     *     double value = Double.parseDouble(map.string(...));
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigInteger value = scalar.bigIntegerValue(...);
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found double or -1.0 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable double.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found long or <code>null</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
      */
-    default double doubleNumber(final String key) {
-        return this.doubleNumber(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+    default BigInteger bigIntegerNumber(String key, int radix) {
+        return bigIntegerNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                radix);
     }
-
+    
     /**
-     * Convenience method to directly read a double value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a BigInteger value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
-     *     double value = Double.parseDouble(map.string(...));
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigInteger value = scalar.bigIntegerValue(...);
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found double or -1.0 if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable double.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found BigInteger or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
      */
-    default double doubleNumber(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return Double.parseDouble(((Scalar) value).value());
+    default BigInteger bigIntegerNumber(YamlNode key, int radix) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return null;
         }
-        return -1.0;
+        return value.bigIntegerValue(radix);
     }
-
+    
     /**
-     * Convenience method to directly read a long value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a BigInteger value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
-     *     long value = Long.parseLong(map.string(...));
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigInteger value = scalar.bigIntegerValue();
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found long or -1L if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable long.
+     * 
+     * @return Found BigInteger or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
      */
-    default long longNumber(final String key) {
-        return this.longNumber(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+    default BigInteger bigIntegerNumber(String key) {
+        return bigIntegerNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
     }
-
+    
     /**
-     * Convenience method to directly read a long value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a BigInteger value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
-     *     long value = Long.parseLong(map.string(...));
+     *     Scalar scalar = map.yamlScalar(...);
+     *     BigInteger value = scalar.bigIntegerValue();
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found long or -1L if there is no value for the key,
-     *  or the value is not a Scalar.
-     * @throws NumberFormatException - if the Scalar value
-     *  is not a parsable long.
+     * 
+     * @return Found BigInteger or <code>null</code> if there is no value for
+     * the key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
      */
-    default long longNumber(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return Long.parseLong(((Scalar) value).value());
+    default BigInteger bigIntegerNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return null;
         }
-        return -1L;
+        return value.bigIntegerValue();
     }
-
+    
     /**
-     * Convenience method to directly read a LocalDate value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a long value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     long value = scalar.longValue(radix);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found long or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default long longNumber(String key, int radix) {
+        return longNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                radix);
+    }
+    
+    /**
+     * Convenience method to directly read a long value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     long value = scalar.longValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found long or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigDecimal.
+     * 
+     * @since 6.0.2
+     */
+    default long longNumber(YamlNode key, int radix) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.longValue(radix);
+    }
+    
+    /**
+     * Convenience method to directly read a long value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     long value = scalar.longValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found long or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable long.
+     */
+    default long longNumber(String key) {
+        return longNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a long value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     long value = scalar.longValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found long or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable long.
+     */
+    default long longNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.longValue();
+    }
+    
+    /**
+     * Convenience method to directly read a integer value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     int value = scalar.intValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found integer or <code>-1</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default int integer(String key, int radix) {
+        return integer(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                radix);
+    }
+    
+    /**
+     * Convenience method to directly read a integer value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     int value = scalar.intValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found integer or <code>-1</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default int integer(YamlNode key, int radix) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.intValue(radix);
+    }
+    
+    /**
+     * Convenience method to directly read a integer value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     int value = scalar.intValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found integer or <code>-1</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * integer.
+     */
+    default int integer(String key) {
+        return integer(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a integer value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     int value = scalar.intValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found integer or <code>-1</code> if there is no value for the
+     * key, or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * integer.
+     */
+    default int integer(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.intValue();
+    }
+    
+    /**
+     * Convenience method to directly read a short value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     short value = scalar.shortValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found short or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default short shortNumber(String key, int radix) {
+        return shortNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                radix);
+    }
+    
+    /**
+     * Convenience method to directly read a short value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     short value = scalar.shortValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found short or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default short shortNumber(YamlNode key, int radix) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.shortValue(radix);
+    }
+    
+    /**
+     * Convenience method to directly read a short value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     short value = scalar.shortValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found short or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * short.
+     * 
+     * @since 6.0.2
+     */
+    default short shortNumber(String key) {
+        return shortNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a short value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     short value = scalar.shortValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found short or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * short.
+     * 
+     * @since 6.0.2
+     */
+    default short shortNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.shortValue();
+    }
+    
+    /**
+     * Convenience method to directly read a byte value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     byte value = scalar.byteValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found byte or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default byte byteNumber(String key, int radix) {
+        return byteNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar(),
+                radix);
+    }
+    
+    /**
+     * Convenience method to directly read a byte value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     byte value = scalar.byteValue(...);
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * @param radix The radix to be used in interpreting the scalar value.
+     * 
+     * @return Found byte or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable
+     * BigInteger.
+     * 
+     * @since 6.0.2
+     */
+    default byte byteNumber(YamlNode key, int radix) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.byteValue(radix);
+    }
+    
+    /**
+     * Convenience method to directly read a byte value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     byte value = scalar.byteValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found byte or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable byte.
+     * 
+     * @since 6.0.2
+     */
+    default byte byteNumber(String key) {
+        return byteNumber(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
+    }
+    
+    /**
+     * Convenience method to directly read a byte value from this map. It is
+     * equivalent to:
+     * 
+     * <pre>
+     *     YamlMapping map = ...;
+     *     Scalar scalar = map.yamlScalar(...);
+     *     byte value = scalar.byteValue();
+     * </pre>
+     * 
+     * @param key The key of the value.
+     * 
+     * @return Found byte or <code>-1</code> if there is no value for the key,
+     * or the value is not a Scalar.
+     * 
+     * @throws NumberFormatException If the Scalar value is not a parsable byte.
+     * 
+     * @since 6.0.2
+     */
+    default byte byteNumber(YamlNode key) {
+        Scalar value = yamlScalar(key);
+        
+        if (value == null) {
+            return -1;
+        }
+        return value.byteValue();
+    }
+    
+    /**
+     * Convenience method to directly read a LocalDate value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
      *     LocalDate date = LocalDate.parse(map.string(...));
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found LocalDate or null if there is no value for the key,
-     *  or the value is not a Scalar.
+     * 
+     * @return Found LocalDate or null if there is no value for the key, or the
+     * value is not a Scalar.
+     * 
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
-    default LocalDate date(final String key) {
-        return this.date(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+    default LocalDate date(String key) {
+        return date(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
     }
-
+    
     /**
-     * Convenience method to directly read a LocalDate value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a LocalDate value from this map. It
+     * is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
      *     LocalDate date = LocalDate.parse(map.string(...));
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found LocalDate or null if there is no value for the key,
-     *  or the value is not a Scalar.
+     * 
+     * @return Found LocalDate or null if there is no value for the key, or the
+     * value is not a Scalar.
+     * 
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
-    default LocalDate date(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return LocalDate.parse(((Scalar) value).value());
+    default LocalDate date(YamlNode key) {
+        String value = string(key);
+        
+        if (value == null) {
+            return null;
         }
-        return null;
+        return LocalDate.parse(value);
     }
-
+    
     /**
-     * Convenience method to directly read a LocalDateTime value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a LocalDateTime value from this map.
+     * It is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
      *     LocalDateTime dateTime = LocalDateTime.parse(map.string(...));
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found LocalDateTime or null if there is no value for the key,
-     *  or the value is not a Scalar.
+     * 
+     * @return Found LocalDateTime or null if there is no value for the key, or
+     * the value is not a Scalar.
+     * 
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
-    default LocalDateTime dateTime(final String key) {
-        return this.dateTime(
-            Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar()
-        );
+    default LocalDateTime dateTime(String key) {
+        return dateTime(
+                Yaml.createYamlScalarBuilder().addLine(key).buildPlainScalar());
     }
-
+    
     /**
-     * Convenience method to directly read a LocalDateTime value
-     * from this map. It is equivalent to:
+     * Convenience method to directly read a LocalDateTime value from this map.
+     * It is equivalent to:
+     * 
      * <pre>
      *     YamlMapping map = ...;
      *     LocalDateTime dateTime = LocalDateTime.parse(map.string(...));
      * </pre>
+     * 
      * @param key The key of the value.
-     * @return Found LocalDateTime or null if there is no value for the key,
-     *  or the value is not a Scalar.
+     * 
+     * @return Found LocalDateTime or null if there is no value for the key, or
+     * the value is not a Scalar.
+     * 
      * @throws DateTimeParseException - if the Scalar value cannot be parsed.
      */
-    default LocalDateTime dateTime(final YamlNode key) {
-        final YamlNode value = this.value(key);
-        if(value instanceof Scalar) {
-            return LocalDateTime.parse(((Scalar) value).value());
+    default LocalDateTime dateTime(YamlNode key) {
+        String value = string(key);
+        
+        if (value == null) {
+            return null;
         }
-        return null;
+        return LocalDateTime.parse(value);
     }
 }


### PR DESCRIPTION
After some time using this library, I have found it s annoying to have to convert myself the Scalar into a java primitive type like booleans, shorts, bytes or BigIntegers (When reading a hex of a color) so i have made this addon for this library where the Scalar interface has all the java primitive type convertions of it String value.