### PR TITLE
Add test for RtYamlLine.indentation and YamlIndentationException.<init>

### DIFF
--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -35,7 +35,6 @@ import java.util.Set;
 import org.apache.commons.io.IOUtils;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
-import org.junit.Ignore;
 import org.junit.Test;
 
 /**

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -33,6 +33,9 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 
 import java.io.File;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
 
 /**
  * Test cases regarding an input YAML's indentation, particularly
@@ -144,4 +147,32 @@ public final class YamlIndentationTestCase {
             Matchers.equalTo("rultor")
         );
     }
+
+    /**
+     * A badly indented YAML sequence throws an exception.
+     * @throws Exception If something goes wrong.
+     */
+    @Test
+    public void testIndentationAndYamlIndentationException() throws Exception {
+        try {
+            final List<YamlLine> lines = new ArrayList<>();
+            lines.add(new RtYamlLine("value1", 1));
+            lines.add(new RtYamlLine(" lGvSz", 2));
+            lines.add(new RtYamlLine("value3", 3));
+            final YamlLines yamlLines = new AllYamlLines(lines);
+            final YamlNode seq = yamlLines.toYamlNode(
+                    new RtYamlLine("foldedSequence:|-", 0), false);
+            final Collection<YamlNode> values = ((YamlSequence) seq).values();
+            MatcherAssert.assertThat(
+                    "testIndentationAndYamlIndentationException "
+                    + "should have thrown YamlIndentationException",
+                    false);
+        } catch (final YamlIndentationException expected) {
+            MatcherAssert.assertThat(expected.getMessage(), Matchers.equalTo(
+                    "Indentation of line 3 [lGvSz] is greater "
+                    + "than the one of line 2 [value1]. "
+                    + "It should be less or equal."));
+        }
+    }
+
 }

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -30,6 +30,7 @@ package com.amihaiemil.eoyaml;
 import com.amihaiemil.eoyaml.exceptions.YamlIndentationException;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
+import org.junit.Assert;
 import org.junit.Test;
 
 import java.io.File;
@@ -153,7 +154,7 @@ public final class YamlIndentationTestCase {
      * @throws Exception If something goes wrong.
      */
     @Test
-    public void testIndentationAndYamlIndentationException() throws Exception {
+    public void badlyIndentedSequenceThrowsException() throws Exception {
         try {
             final List<YamlLine> lines = new ArrayList<>();
             lines.add(new RtYamlLine("value1", 1));
@@ -163,10 +164,8 @@ public final class YamlIndentationTestCase {
             final YamlNode seq = yamlLines.toYamlNode(
                     new RtYamlLine("foldedSequence:|-", 0), false);
             final Collection<YamlNode> values = ((YamlSequence) seq).values();
-            MatcherAssert.assertThat(
-                    "testIndentationAndYamlIndentationException "
-                    + "should have thrown YamlIndentationException",
-                    false);
+            Assert.fail("badlyIntendedSequenceThrowsException "
+                    + "should have thrown YamlIndentationException");
         } catch (final YamlIndentationException expected) {
             MatcherAssert.assertThat(expected.getMessage(), Matchers.equalTo(
                     "Indentation of line 3 [lGvSz] is greater "


### PR DESCRIPTION
Hey 😊
I want to contribute the following test:

Test that a `YamlIndentationException` is thrown.
This tests the methods [`RtYamlLine.indentation`](https://github.com/decorators-squad/eo-yaml/blob/2c088042c3c4cdac75971547186c2f06c9ef1b72/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java#L132) and [`YamlIndentationException.<init>`](https://github.com/decorators-squad/eo-yaml/blob/2c088042c3c4cdac75971547186c2f06c9ef1b72/src/main/java/com/amihaiemil/eoyaml/exceptions/YamlIndentationException.java#L49).
This test is based on the test [`turnsIntoFoldedSequence`](https://github.com/decorators-squad/eo-yaml/blob/2c088042c3c4cdac75971547186c2f06c9ef1b72/src/test/java/com/amihaiemil/eoyaml/AllYamlLinesTest.java#L115).

Curious to hear what you think!

(I wrote this test as part of a research study at TU Delft. [Find out more](https://github.com/lacinoire/lacinoire/blob/main/README.md))