### PR TITLE
#517 The key of an entry must be followed by a space

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -27,11 +27,15 @@
  */
 package com.amihaiemil.eoyaml;
 
-import static com.amihaiemil.eoyaml.YamlLine.UNKNOWN_LINE_NUMBER;
-
 import com.amihaiemil.eoyaml.exceptions.YamlReadingException;
-import java.util.*;
+
+import java.util.Iterator;
+import java.util.LinkedHashSet;
+import java.util.Set;
+import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+
+import static com.amihaiemil.eoyaml.YamlLine.UNKNOWN_LINE_NUMBER;
 
 /**
  * YamlMapping read from somewhere. YAML directives and
@@ -43,6 +47,8 @@ import java.util.regex.Pattern;
  * @since 1.0.0
  */
 final class ReadYamlMapping extends BaseYamlMapping {
+
+    private static final Pattern KEY_PATTERN = Pattern.compile("^-?\\s*(?<key>.+):(|\\s.*)$");
 
     /**
      * Yaml line just previous to the one where this mapping starts. E.g.
@@ -158,18 +164,12 @@ final class ReadYamlMapping extends BaseYamlMapping {
                 if(!trimmed.contains(":")) {
                     continue;
                 }
-                final String key;
-                if(trimmed.startsWith("-")) {
-                    key = trimmed.substring(
-                        1, trimmed.lastIndexOf(":")
-                    ).trim();
-                } else {
-                    key = trimmed.substring(
-                        0, trimmed.lastIndexOf(":")
-                    ).trim();
-                }
-                if(!key.isEmpty()) {
-                    keys.add(new PlainStringScalar(key));
+                final Matcher matcher = KEY_PATTERN.matcher(trimmed);
+                if (matcher.matches()) {
+                    final String key = matcher.group("key");
+                    if (!key.isEmpty()) {
+                        keys.add(new PlainStringScalar(key));
+                    }
                 }
             }
             prev = line;

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -237,8 +237,8 @@ final class ReadYamlSequence extends BaseYamlSequence {
      */
     private boolean mappingStartsAtDash(final YamlLine dashLine) {
         final String trimmed = dashLine.trimmed();
-        final boolean escapedScalar = trimmed.matches("^[ ]*\\-[ ]*\".*\"$")
-            || trimmed.matches("^[ ]*\\-[ ]*\'.*\'$");
-        return trimmed.matches("^.*\\-.*\\:.*$") && !escapedScalar;
+        final boolean escapedScalar = trimmed.matches("^\\s*-\\s*\".*\"$")
+            || trimmed.matches("^\\s*-\\s*'.*'$");
+        return trimmed.matches("^.*-.+:(|\\s.*)$") && !escapedScalar;
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlInput.java
@@ -193,8 +193,8 @@ final class RtYamlInput implements YamlInput {
     private boolean mappingStartsAtDash(final String line){
         //line without indentation.
         final String trimmed = line.trim();
-        final boolean escapedScalar = trimmed.matches("^[ ]*-[ ]*\".*\"$")
-            || trimmed.matches("^[ ]*-[ ]*'.*'$");
-        return trimmed.matches("^[ ]*-.*:.+$") && !escapedScalar;
+        final boolean escapedScalar = trimmed.matches("^\\s*-\\s*\".*\"$")
+            || trimmed.matches("^\\s*-\\s*'.*'$");
+        return trimmed.matches("^\\s*-.+:\\s.*$") && !escapedScalar;
     }
 }

--- a/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
+++ b/src/main/java/com/amihaiemil/eoyaml/SameIndentationLevel.java
@@ -116,9 +116,9 @@ final class SameIndentationLevel implements YamlLines {
      */
     private boolean mappingStartsAtDash(final YamlLine dashLine) {
         final String trimmed = dashLine.trimmed();
-        final boolean escapedScalar = trimmed.matches("^[ ]*\\-[ ]*\".*\"$")
-            || trimmed.matches("^[ ]*\\-[ ]*\'.*\'$");
-        return trimmed.matches("^[ ]*\\-.*\\:.+$") && !escapedScalar;
+        final boolean escapedScalar = trimmed.matches("^\\s*-\\s*\".*\"$")
+            || trimmed.matches("^\\s*-\\s*'.*'$");
+        return trimmed.matches("^\\s*-.*:\\s.+$") && !escapedScalar;
     }
 
     /**
@@ -128,9 +128,9 @@ final class SameIndentationLevel implements YamlLines {
      */
     private boolean mapping(final YamlLine dashLine) {
         final String trimmed = dashLine.trimmed();
-        final boolean escapedScalar = trimmed.matches("^[ ]*\".*\"$")
-                || trimmed.matches("^[ ]*\'.*\'$");
-        return trimmed.matches("^[ ]*.*\\:.+$") && !escapedScalar;
+        final boolean escapedScalar = trimmed.matches("^\\s*\".*\"$")
+                || trimmed.matches("^\\s*'.*'$");
+        return trimmed.matches("^.*:\\s.+$") && !escapedScalar;
     }
 
 }

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -118,7 +118,7 @@ final class WellIndented implements YamlLines {
                 YamlLine line = iterator.next();
                 if(!(previous instanceof YamlLine.NullYamlLine)) {
                     int prevIndent = previous.indentation();
-                    if(previous.trimmed().matches("^[ ]*\\-.*\\:.*$")) {
+                    if(previous.trimmed().matches("^\\s*-.*:(|\\s.*)$")) {
                         prevIndent += 2;
                     }
                     int lineIndent = line.indentation();

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlMappingTest.java
@@ -27,17 +27,17 @@
  */
 package com.amihaiemil.eoyaml;
 
+import org.hamcrest.MatcherAssert;
+import org.hamcrest.Matchers;
+import org.junit.Ignore;
+import org.junit.Test;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
-
-import org.hamcrest.MatcherAssert;
-import org.hamcrest.Matchers;
-import org.junit.Ignore;
-import org.junit.Test;
 
 /**
  * Unit tests for {@link ReadYamlMapping}.
@@ -1169,5 +1169,15 @@ public final class ReadYamlMappingTest {
             .equalTo("Some value?"));
         MatcherAssert.assertThat(copy.string("key2"), Matchers
             .equalTo("Some other value."));
+    }
+
+    @Test
+    public void shouldReadKeyProperlyIfValueContainsColon() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("key: value:with-colon", 0));
+        ReadYamlMapping mapping = new ReadYamlMapping(new AllYamlLines(lines));
+
+        MatcherAssert.assertThat(mapping.keys(), Matchers.hasSize(1));
+        MatcherAssert.assertThat(mapping.keys().iterator().next().asScalar().value(), Matchers.equalTo("key"));
     }
 }

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -27,15 +27,15 @@
  */
 package com.amihaiemil.eoyaml;
 
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.Iterator;
-import java.util.List;
-
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Ignore;
 import org.junit.Test;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
 
 /**
  * Unit tests for {@link ReadYamlSequence}.
@@ -483,5 +483,19 @@ public final class ReadYamlSequenceTest {
             new AllYamlLines(new ArrayList<YamlLine>())
         );
         MatcherAssert.assertThat(sequence.toString(), Matchers.isEmptyString());
+    }
+
+    @Test
+    public void dontReturnMappingForScalarWithColon() {
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- scalar:with-colon", 0));
+        final YamlSequence sequence = new ReadYamlSequence(
+                new AllYamlLines(lines)
+        );
+
+        MatcherAssert.assertThat(sequence.values(), Matchers.hasSize(1));
+        YamlNode sequenceItem = sequence.values().iterator().next();
+        MatcherAssert.assertThat(sequenceItem.type(), Matchers.equalTo(Node.SCALAR));
+        MatcherAssert.assertThat(sequenceItem.asScalar().value(), Matchers.equalTo("scalar:with-colon"));
     }
 }

--- a/src/test/resources/issue_517_values_with_colons.yml
+++ b/src/test/resources/issue_517_values_with_colons.yml
@@ -1,0 +1,5 @@
+a_mapping:
+  a_scalar: value:with-colon
+
+a_sequence:
+  - value:with-colon


### PR DESCRIPTION
The current version parses keys wrong if a scalar contains a colon. This PR will fix this by checking for a space after the colon of the key name.

This will fix #517