### PR TITLE
#529 allow empty keys in mapping; lighter indentation rules

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/RtYamlLine.java
@@ -162,7 +162,7 @@ final class RtYamlLine implements YamlLine {
         if("---".equals(this.trimmed())) {
             result = false;
         } else {
-            final String specialCharacters = ":>|-?";
+            final String specialCharacters = "-?";
             final CharSequence prevLineLastChar =
                 this.trimmed().substring(this.trimmed().length() - 1);
             result = specialCharacters.contains(prevLineLastChar);

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -62,11 +62,6 @@ import java.util.List;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 3.1.2
- * @todo #525:60m Please make sure to allow keys with empty values in mappings.
- *  At the moment, if we cannot find the value on the same line, we always
- *  look beneath the key for more-indented lines to be treated as the value,
- *  but this is not always the case. This should be a valid YAML
- *  {key1: value1, key2:,key3: value3}
  */
 final class WellIndented implements YamlLines {
 

--- a/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
+++ b/src/main/java/com/amihaiemil/eoyaml/WellIndented.java
@@ -109,6 +109,8 @@ final class WellIndented implements YamlLines {
      * correct.
      * @checkstyle LineLength (50 lines)
      * @return Iterator over these yaml lines.
+     * @todo #529:60min Remove the guessIndentation logic. It doesn't make
+     *  sense anymore and it's too unpredictible.
      */
     @Override
     public Iterator<YamlLine> iterator() {
@@ -127,37 +129,37 @@ final class WellIndented implements YamlLines {
                     }
                     int lineIndent = line.indentation();
                     if(previous.requireNestedIndentation()) {
-                        if(lineIndent != prevIndent + 2) {
-                            final CharSequence prevLineLastChar =
-                                    previous.trimmed().substring(previous.trimmed().length() - 1);
-                            if (!">|".contains(prevLineLastChar)) {
-                                if (this.guessIndentation) {
-                                    line = new Indented(line, prevIndent + 2);
-                                } else {
-                                    throw new YamlIndentationException(
-                                            "Indentation of line " + (line.number() + 1)
-                                            + " [" + line.trimmed() + "]"
-                                            + " is not ok. It should be greater than the one"
-                                            + " of line " + (previous.number() + 1)
-                                            + " [" + previous.trimmed() + "]"
-                                            + " by 2 spaces."
-                                    );
-                                }
+                        if(lineIndent < prevIndent + 2) {
+                            if (this.guessIndentation) {
+                                line = new Indented(line, prevIndent + 2);
+                            } else {
+                                throw new YamlIndentationException(
+                                    "Indentation of line " + (line.number() + 1)
+                                    + " [" + line.trimmed() + "]"
+                                    + " is not ok. It should be greater than the one"
+                                    + " of line " + (previous.number() + 1)
+                                    + " [" + previous.trimmed() + "]"
+                                    + " by at least 2 spaces."
+                                );
                             }
                         }
                     } else {
                         if(!"---".equals(previous.trimmed()) && lineIndent > prevIndent) {
-                            if(this.guessIndentation) {
-                                line = new Indented(line, prevIndent);
-                            } else {
-                                throw new YamlIndentationException(
-                                    "Indentation of line " + (line.number() + 1)
-                                  + " [" + line.trimmed() + "]"
-                                  + " is greater than the one of line "
-                                  + (previous.number() + 1)
-                                  + " [" + previous.trimmed() + "]. "
-                                  + "It should be less or equal."
-                                );
+                            final CharSequence prevLineLastChar =
+                                previous.trimmed().substring(previous.trimmed().length() - 1);
+                            if (!">|:".contains(prevLineLastChar)) {
+                                if (this.guessIndentation) {
+                                    line = new Indented(line, prevIndent);
+                                } else {
+                                    throw new YamlIndentationException(
+                                        "Indentation of line " + (line.number() + 1)
+                                            + " [" + line.trimmed() + "]"
+                                            + " is greater than the one of line "
+                                            + (previous.number() + 1)
+                                            + " [" + previous.trimmed() + "]. "
+                                            + "It should be less or equal."
+                                    );
+                                }
                             }
                         }
                     }

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlLineTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlLineTest.java
@@ -64,14 +64,6 @@ public final class RtYamlLineTest {
     @Test
     public void requiresNestedIndentation() {
         MatcherAssert.assertThat(
-            new RtYamlLine("this:", 12).requireNestedIndentation(),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
-            new RtYamlLine("this: |> ", 12).requireNestedIndentation(),
-            Matchers.is(true)
-        );
-        MatcherAssert.assertThat(
             new RtYamlLine("this: |- ", 12).requireNestedIndentation(),
             Matchers.is(true)
         );

--- a/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/YamlIndentationTestCase.java
@@ -40,27 +40,13 @@ import java.util.List;
 
 /**
  * Test cases regarding an input YAML's indentation, particularly
- * disabling validation of indentation and trying to guess the correct
- * one.
+ * cases in which the input is not indented properly, we have keys without
+ * values etc.
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 5.1.0
  */
 public final class YamlIndentationTestCase {
-
-    /**
-     * A Yaml mapping containing an unindented sequence throws exception
-     * because of bad indentation.
-     * @throws Exception If something goes wrong.
-     */
-    @Test (expected = YamlIndentationException.class)
-    public void unintendedSequenceException() throws Exception {
-        final YamlMapping map = Yaml.createYamlInput(
-            new File("src/test/resources/badSequenceIndentationInMapping.yml"),
-            Boolean.FALSE
-        ).readYamlMapping();
-        System.out.println(map);
-    }
 
     /**
      * A Yaml mapping containing an unindented sequence can be read
@@ -70,8 +56,7 @@ public final class YamlIndentationTestCase {
     @Test
     public void readsUnintendedSequenceException() throws Exception {
         final YamlMapping map = Yaml.createYamlInput(
-            new File("src/test/resources/badSequenceIndentationInMapping.yml"),
-            Boolean.TRUE
+            new File("src/test/resources/badSequenceIndentationInMapping.yml")
         ).readYamlMapping();
         final YamlSequence developers = map.yamlSequence("developers");
         MatcherAssert.assertThat(
@@ -93,47 +78,31 @@ public final class YamlIndentationTestCase {
     }
 
     /**
-     * A badly indented YAML mapping throws an exception.
+     * A badly indented YAML mapping, which also has an empty key,
+     * is read properly.
      * @throws Exception If something goes wrong.
      */
-    @Test (expected = YamlIndentationException.class)
-    public void complainsOnBadlyIndentedMapping() throws Exception {
+    @Test
+    public void readsBadlyIndentedMappingWithEmptyKey() throws Exception {
         final YamlMapping map = Yaml.createYamlInput(
             new File("src/test/resources/badMappingIndentation.yml"),
             Boolean.FALSE
         ).readYamlMapping();
         System.out.println(map);
-    }
-
-    /**
-     * A badly indented YAML can be read if we try to guess the indentation.
-     * @throws Exception If something goes wrong.
-     */
-    @Test
-    public void readsBadlyIndentedMapping() throws Exception {
-        final YamlMapping map = Yaml.createYamlInput(
-            new File("src/test/resources/badMappingIndentation.yml"),
-            Boolean.TRUE
-        ).readYamlMapping();
-        System.out.println(map);
         MatcherAssert.assertThat(
-            map.string("name"),
-            Matchers.equalTo("eo-yaml")
+            map.string("name"), Matchers.equalTo("eo-yaml")
         );
         MatcherAssert.assertThat(
-            map.yamlSequence("developers"),
-            Matchers.nullValue()
+            map.string("contributors"), Matchers.nullValue()
         );
         MatcherAssert.assertThat(
-            map.yamlMapping("contributors"),
-            Matchers.notNullValue()
+            map.value("contributors").comment().value(),
+            Matchers.equalTo("empty key...")
         );
-        final YamlSequence developers = map
-            .yamlMapping("contributors")
-            .yamlSequence("developers");
+        final YamlSequence developers = map.yamlSequence("developers");
         MatcherAssert.assertThat(
-            developers,
-            Matchers.iterableWithSize(3)
+            developers.size(),
+            Matchers.equalTo(3)
         );
         MatcherAssert.assertThat(
             developers.string(0),
@@ -148,6 +117,7 @@ public final class YamlIndentationTestCase {
             Matchers.equalTo("rultor")
         );
     }
+
 
     /**
      * A badly indented YAML sequence throws an exception.

--- a/src/test/resources/badMappingIndentation.yml
+++ b/src/test/resources/badMappingIndentation.yml
@@ -1,6 +1,6 @@
 name: eo-yaml
-contributors:
+contributors: # empty key...
 developers:
-- amihaiemil # Elements of this sequence should be indented by 4 spaces.
+- amihaiemil # Elements of this sequence should be indented deeper.
 - sherif
 - rultor


### PR DESCRIPTION
PR for #529 

- Allow empty keys in mapping (this was previously throwing an indentation exaption):

```yaml
architect: amihaiemil
contributors:
# exception was being thrown at this line, because contributors: was not allowed to have empty value
developers:
  - amihaiemil
  - shaik
  - rultor
```

- Don't throw exception anymore if sequence under mapping key is not indented properly:

```yaml
architect: amihaiemil
contributors:
developers:
- amihaiemil # these 3 lines should normally have a deeper indentation
- shaik
- rultor
```
- Remove the ``2-by-2`` mandatory indentation. Indentation can now be however many spaces:

```yaml
architect: amihaiemil
contributors:
developers:
        - amihaiemil # this indentation works now, previously you would receive an indentation exception
        - shaik
        - rultor
```

Added TODO to remove the ``guessIndentation`` logic (not needed anymore and it is too unstable anyway). 
