### PR TITLE
#547 regex updates

### DIFF
--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -1248,15 +1248,14 @@ public final class RtYamlInputTest {
             new FileInputStream("src/test/resources/" + filename)
         ).readYamlMapping();
 
-        System.out.println(">>>>>>>>>");
         System.out.println(read);
-        System.out.println("<<<<<<<<<");
 
         final YamlMapping filter = read.yamlMapping("filter");
         MatcherAssert.assertThat(
             filter.string("input"),
             Matchers.equalTo("${ {vegetables: .vegetables} }")
         );
+        //@checkstyle LineLength (5 lines)
         MatcherAssert.assertThat(
             filter.string("output"),
             Matchers.equalTo(

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -1236,6 +1236,36 @@ public final class RtYamlInputTest {
     }
 
     /**
+     * Unit test for issue 547.
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void shouldReadEscapedScalarsProperly()
+        throws IOException {
+        final String filename = "issue_547_escaped_special_chars.yml";
+
+        final YamlMapping read = new RtYamlInput(
+            new FileInputStream("src/test/resources/" + filename)
+        ).readYamlMapping();
+
+        System.out.println(">>>>>>>>>");
+        System.out.println(read);
+        System.out.println("<<<<<<<<<");
+
+        final YamlMapping filter = read.yamlMapping("filter");
+        MatcherAssert.assertThat(
+            filter.string("input"),
+            Matchers.equalTo("${ {vegetables: .vegetables} }")
+        );
+        MatcherAssert.assertThat(
+            filter.string("output"),
+            Matchers.equalTo(
+                "${ {vegetables: [.vegetables[] | select(.veggieLike == true)]} }"
+            )
+        );
+    }
+
+    /**
      * Read a test resource file's contents.
      * @param fileName File to read.
      * @return File's contents as String.

--- a/src/test/resources/issue_547_escaped_special_chars.yml
+++ b/src/test/resources/issue_547_escaped_special_chars.yml
@@ -1,0 +1,3 @@
+filter:
+  input: "${ {vegetables: .vegetables} }"
+  output: "${ {vegetables: [.vegetables[] | select(.veggieLike == true)]} }"


### PR DESCRIPTION
PR for #547 

Updated regexes to take into account escaped keys (they may contain ``:`` which is misread as YAML symbol);
Added names for the regex groups in ReadYamlScalar, instead of indexes. 
Added unit test to make sure the case of #547 is now valid.