### PR TITLE
fix for second example in #546

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlMapping.java
@@ -42,6 +42,7 @@ import static com.amihaiemil.eoyaml.YamlLine.UNKNOWN_LINE_NUMBER;
  * document start/end markers are ignored. This is assumed
  * to be a plain YAML mapping.
  * @checkstyle CyclomaticComplexity (300 lines)
+ * @checkstyle ExecutableStatementCount (300 lines)
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
@@ -132,10 +133,10 @@ final class ReadYamlMapping extends BaseYamlMapping {
         YamlLine prev = new YamlLine.NullYamlLine();
         for (final YamlLine line : this.significant) {
             final String trimmed = line.trimmed();
-            if(trimmed.startsWith(":")
-                || (trimmed.startsWith("-")
-                        && !(prev instanceof YamlLine.NullYamlLine))
-            ) {
+            if(trimmed.startsWith("-")
+                && !(prev instanceof YamlLine.NullYamlLine)) {
+                break;
+            } else if(trimmed.startsWith(":")) {
                 continue;
             } else if ("?".equals(trimmed)) {
                 keys.add(this.significant.toYamlNode(line));

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlInputTest.java
@@ -1236,6 +1236,45 @@ public final class RtYamlInputTest {
     }
 
     /**
+     * Unit test for issue 546, second example with accidentally interpolated
+     * mapping in a sequence..
+     * @throws IOException If something goes wrong.
+     */
+    @Test
+    public void shouldIterateKeysWhenMappingStartsAtDashNoInterpolation()
+        throws IOException {
+        final String filename = "issue_546_mapping_starts_at_dash_2.yml";
+
+        final YamlMapping read = new RtYamlInput(
+            new FileInputStream("src/test/resources/" + filename)
+        ).readYamlMapping();
+
+        System.out.println(read);
+
+        final YamlSequence holders = read.yamlSequence("holders");
+        MatcherAssert.assertThat(holders.size(), Matchers.equalTo(2));
+
+        final YamlMapping first = holders.yamlMapping(0);
+        MatcherAssert.assertThat(first.keys().size(), Matchers.equalTo(1));
+        MatcherAssert.assertThat(
+            first.yamlSequence("array").string(0),
+            Matchers.equalTo("arr1")
+        );
+
+        final YamlMapping second = holders.yamlMapping(1);
+        MatcherAssert.assertThat(second.keys().size(), Matchers.equalTo(2));
+        MatcherAssert.assertThat(
+            second.yamlSequence("array2").string(0),
+            Matchers.equalTo("arr2")
+        );
+        MatcherAssert.assertThat(
+            second.string("value"),
+            Matchers.equalTo("test1")
+        );
+
+    }
+
+    /**
      * Unit test for issue 547.
      * @throws IOException If something goes wrong.
      */

--- a/src/test/resources/issue_546_mapping_starts_at_dash_2.yml
+++ b/src/test/resources/issue_546_mapping_starts_at_dash_2.yml
@@ -1,0 +1,6 @@
+holders:
+  - array:
+      - arr1
+  - array2:
+      - arr2
+    value: test1


### PR DESCRIPTION
PR for #546 (second case, after the first bugfix).

When reading the keys of a mapping, break (instead of continuing iteration) when finding that a sequence starts at the same level.
Added test case. 