### PR TITLE
parsing: missed elements in mapping

### DIFF
--- a/src/test/resources/issue_556_seq_folded_blocks.yml
+++ b/src/test/resources/issue_556_seq_folded_blocks.yml
@@ -1,0 +1,19 @@
+id: roomreadings
+version: 1.0
+specVersion: 0.8
+name: Room Temp and Humidity Workflow
+start: ConsumeReading
+states:
+  - name: ConsumeReading
+    type: event
+    end: true
+    onEvents:
+      - eventDataFilter:
+          toStateData: "${ .readings }"
+        actions:
+          - functionRef:
+              refName: LogReading
+        eventRefs:
+          - TemperatureEvent
+          - HumidityEvent
+


### PR DESCRIPTION
onEvents is a seq, that has a mapping, but parser only can read the first on - eventDataFilter, actions and eventRefs are missed.