### PR TITLE
possible fix for question mask and hash code symbol in scalar

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/YamlLine.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlLine.java
@@ -60,8 +60,11 @@ interface YamlLine extends Comparable<YamlLine> {
         int i = 0;
         while(i < trimmed.length()) {
             if(i > 0 && trimmed.charAt(i) == '#') {
-                trimmed = trimmed.substring(0, i);
-                break;
+                // Comments must be separated from other tokens by white space characters.
+                if(trimmed.charAt(i - 1) == ' ') {
+                    trimmed = trimmed.substring(0, i);
+                    break;
+                }
             } else if(trimmed.charAt(i) == '"') {
                 i++;
                 while(i < trimmed.length() && trimmed.charAt(i) != '"') {
@@ -154,6 +157,11 @@ interface YamlLine extends Comparable<YamlLine> {
             final CharSequence prevLineLastChar =
                 this.trimmed().substring(this.trimmed().length() - 1);
             result = specialCharacters.contains(prevLineLastChar);
+            if(result && prevLineLastChar.charAt(0)  == '?' && this.trimmed().length() > 1) {
+                return false;
+            }
+
+
         }
         return result;
     }


### PR DESCRIPTION
? case: according to spec, mapping key token must have no token before, so we can check length of the scalar
$ case: according to spec : Comments must be separated from other tokens by white space characters.

so if there is non-white space char, we can assume, it's not a beginning of the comment

WDYT?