### PR TITLE
Add method YamlSequence.yamlNode

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/YamlSequence.java
@@ -68,6 +68,23 @@ public interface YamlSequence extends YamlNode, Iterable<YamlNode> {
     }
 
     /**
+     * Get the Yaml node from the given index.
+     * @param index Integer index.
+     * @return Yaml node.
+     */
+    default YamlNode yamlNode(final int index) {
+        YamlNode result = null;
+        int count = 0;
+        for (final YamlNode node : this.values()) {
+            if (count == index) {
+                result = node;
+            }
+            count = count + 1;
+        }
+        return result;
+    }
+
+    /**
      * Get the Yaml mapping  from the given index.
      * @param index Integer index.
      * @return Yaml mapping.

--- a/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/RtYamlSequenceTest.java
@@ -179,6 +179,21 @@ public final class RtYamlSequenceTest {
     }
 
     /**
+     * RtYamlSequence can return a YamlNode.
+     */
+    @Test
+    public void returnsYamlNode() {
+        List<YamlNode> nodes = new LinkedList<>();
+        nodes.add(new PlainStringScalar("test"));
+        nodes.add(Mockito.mock(YamlMapping.class));
+        nodes.add(new PlainStringScalar("mihai"));
+        YamlSequence seq = new RtYamlSequence(nodes);
+        MatcherAssert.assertThat(
+            seq.yamlNode(1), Matchers.notNullValue()
+        );
+    }
+
+    /**
      * RtYamlSequence can return a YamlMapping.
      */
     @Test


### PR DESCRIPTION
This returns the YamlNode at position `index` without casting it to a subtype.

I tried to mirror the style of the rest of the file, and to add a unit test.