### PR TITLE
#608 read flow nodes from a ReadYamlSequence (at the dash and after, inline or multiline)

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
+++ b/src/main/java/com/amihaiemil/eoyaml/AllYamlLines.java
@@ -49,7 +49,7 @@ final class AllYamlLines implements YamlLines {
      * There are 3 types of nodes: scalar, sequence and mapping.  This matches
      * either a sequence or map - no match indicates it's a scalar.
      *
-     * Does not handle flow mapping
+     * Does not handle flow-style YAML!
      * (https://yaml.org/spec/1.2/spec.html#id2790832).
      *
      * A sequence (group 2) is:
@@ -132,6 +132,7 @@ final class AllYamlLines implements YamlLines {
     /**
      * Try to figure out what YAML node (mapping, sequence or scalar) is found
      * after the given line.
+     * @checkstyle CyclomaticComplexity (200 lines)
      * @param prev YamlLine just previous to the node we're trying to find.
      * @return Found YamlNode.
      */
@@ -161,6 +162,10 @@ final class AllYamlLines implements YamlLines {
                 new Edited(prev.trimmed()
                     + " null #" + prev.comment(), prev)
             );
+        } else if(first.trimmed().matches("^\\s*-?\\s*\\[.*$")) {
+            node = new ReadFlowSequence(prev, this);
+        } else if(first.trimmed().matches("^\\s*-?\\s*\\{.*$")) {
+            node = new ReadFlowMapping(prev, this);
         } else {
             Matcher matcher = SEQUENCE_OR_MAP.matcher(first.trimmed());
             if (matcher.matches()) {

--- a/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadYamlSequence.java
@@ -36,9 +36,6 @@ import java.util.List;
  * @author Mihai Andronache (amihaiemil@gmail.com)
  * @version $Id$
  * @since 1.0.0
- * @todo #600:120min At the moment we are only able to read inline flow
- *  nodes (flow-nodes starting at the dash). Make sure we also can read
- *  flow-style nodes spanning multiple lines and starting as an inner node.
  */
 final class ReadYamlSequence extends BaseYamlSequence {
 
@@ -134,6 +131,7 @@ final class ReadYamlSequence extends BaseYamlSequence {
                             )
                         );
                     } else if(this.flowSequenceStartsAtDash(line)) {
+                        innerValueStarted = true;
                         kids.add(
                             new ReadFlowSequence(
                                 this.getPreviousLine(line),
@@ -141,6 +139,7 @@ final class ReadYamlSequence extends BaseYamlSequence {
                             )
                         );
                     } else if(this.flowMappingStartsAtDash(line)) {
+                        innerValueStarted = true;
                         kids.add(
                             new ReadFlowMapping(
                                 this.getPreviousLine(line),

--- a/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadYamlSequenceTest.java
@@ -250,7 +250,216 @@ public final class ReadYamlSequenceTest {
         MatcherAssert.assertThat(flow.string(0), Matchers.equalTo("a"));
         MatcherAssert.assertThat(flow.string(1), Matchers.equalTo("b"));
         MatcherAssert.assertThat(flow.string(2), Matchers.equalTo("c"));
+    }
 
+    /**
+     * ReadYamlSequence can return the inline YamlSequence (in flow style)
+     * from a given index.
+     */
+    @Test
+    public void returnsDashMultilineFlowYamlSequenceFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("- [a,", 3));
+        lines.add(new RtYamlLine("b,", 4));
+        lines.add(new RtYamlLine("c", 5));
+        lines.add(new RtYamlLine("]", 6));
+        lines.add(new RtYamlLine("- otherScalar", 8));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlSequence flow = sequence.yamlSequence(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlSequence.class)
+        );
+        MatcherAssert.assertThat(flow.size(), Matchers.equalTo(3));
+        MatcherAssert.assertThat(flow.string(0), Matchers.equalTo("a"));
+        MatcherAssert.assertThat(flow.string(1), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string(2), Matchers.equalTo("c"));
+    }
+
+
+    /**
+     * ReadYamlSequence can return the inline YamlSequence (in flow style)
+     * from a given index.
+     */
+    @Test
+    public void returnsAfterDashInlineFlowYamlSequenceFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("-", 3));
+        lines.add(new RtYamlLine("  [a, b, c]", 4));
+        lines.add(new RtYamlLine("- otherScalar", 5));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlSequence flow = sequence.yamlSequence(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlSequence.class)
+        );
+        MatcherAssert.assertThat(flow.size(), Matchers.equalTo(3));
+        MatcherAssert.assertThat(flow.string(0), Matchers.equalTo("a"));
+        MatcherAssert.assertThat(flow.string(1), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string(2), Matchers.equalTo("c"));
+    }
+
+    /**
+     * ReadYamlSequence can return the inline YamlSequence (in flow style)
+     * from a given index.
+     */
+    @Test
+    public void returnsAfterDashMultilineFlowYamlSequenceFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("-", 3));
+        lines.add(new RtYamlLine("  [a,", 4));
+        lines.add(new RtYamlLine(" b,", 5));
+        lines.add(new RtYamlLine(" c", 6));
+        lines.add(new RtYamlLine("]", 7));
+        lines.add(new RtYamlLine("- otherScalar", 8));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlSequence flow = sequence.yamlSequence(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlSequence.class)
+        );
+        MatcherAssert.assertThat(flow.size(), Matchers.equalTo(3));
+        MatcherAssert.assertThat(flow.string(0), Matchers.equalTo("a"));
+        MatcherAssert.assertThat(flow.string(1), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string(2), Matchers.equalTo("c"));
+    }
+
+    /**
+     * ReadYamlSequence can return the inline YamlMapping (in flow style)
+     * from a given index.
+     */
+    @Test
+    public void returnsInlineFlowYamlMappingFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("- {a:b, c:d, e:f}", 3));
+        lines.add(new RtYamlLine("- otherScalar", 4));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping flow = sequence.yamlMapping(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlMapping.class)
+        );
+        MatcherAssert.assertThat(flow.keys(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.values(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.string("a"), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string("c"), Matchers.equalTo("d"));
+        MatcherAssert.assertThat(flow.string("e"), Matchers.equalTo("f"));
+    }
+
+    /**
+     * ReadYamlSequence can return the inline YamlMapping (in flow style)
+     * from a given index, present after the dash.
+     */
+    @Test
+    public void returnsAfterDashInlineFlowYamlMappingFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("-", 3));
+        lines.add(new RtYamlLine("  {a:b, c:d, e:f}", 4));
+        lines.add(new RtYamlLine("- otherScalar", 5));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping flow = sequence.yamlMapping(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlMapping.class)
+        );
+        MatcherAssert.assertThat(flow.keys(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.values(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.string("a"), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string("c"), Matchers.equalTo("d"));
+        MatcherAssert.assertThat(flow.string("e"), Matchers.equalTo("f"));
+    }
+
+    /**
+     * ReadYamlSequence can return the multiline YamlMapping (in flow style)
+     * from a given index, starting at the dash.
+     */
+    @Test
+    public void returnsDashMultilineFlowYamlMappingFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("- {a:b,", 3));
+        lines.add(new RtYamlLine("c:d,", 4));
+        lines.add(new RtYamlLine("e:f", 5));
+        lines.add(new RtYamlLine("}", 6));
+        lines.add(new RtYamlLine("- otherScalar", 8));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping flow = sequence.yamlMapping(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlMapping.class)
+        );
+        MatcherAssert.assertThat(flow.keys(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.values(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.string("a"), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string("c"), Matchers.equalTo("d"));
+        MatcherAssert.assertThat(flow.string("e"), Matchers.equalTo("f"));
+    }
+
+    /**
+     * ReadYamlSequence can return the multiline YamlMapping (in flow style)
+     * from a given index, starting at after the dash.
+     */
+    @Test
+    public void returnsAfterDashMultilineFlowYamlMappingFromIndex(){
+        final List<YamlLine> lines = new ArrayList<>();
+        lines.add(new RtYamlLine("- ", 0));
+        lines.add(new RtYamlLine("  - rultor", 1));
+        lines.add(new RtYamlLine("  - 0pdd", 2));
+        lines.add(new RtYamlLine("- ", 3));
+        lines.add(new RtYamlLine("  {a:b,", 4));
+        lines.add(new RtYamlLine("  c:d,", 5));
+        lines.add(new RtYamlLine(" e:f", 6));
+        lines.add(new RtYamlLine("}", 7));
+        lines.add(new RtYamlLine("- otherScalar", 8));
+        final YamlSequence sequence = new ReadYamlSequence(
+            new AllYamlLines(lines)
+        );
+        System.out.println(sequence);
+        final YamlMapping flow = sequence.yamlMapping(1);
+        MatcherAssert.assertThat(flow, Matchers.notNullValue());
+        MatcherAssert.assertThat(
+            flow, Matchers.instanceOf(YamlMapping.class)
+        );
+        MatcherAssert.assertThat(flow.keys(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.values(), Matchers.hasSize(3));
+        MatcherAssert.assertThat(flow.string("a"), Matchers.equalTo("b"));
+        MatcherAssert.assertThat(flow.string("c"), Matchers.equalTo("d"));
+        MatcherAssert.assertThat(flow.string("e"), Matchers.equalTo("f"));
     }
 
     /**


### PR DESCRIPTION
PR for #608 

We are now able to fetch flow-style sequences and mappings from a block-style ``ReadYamlSequence``.
Added tests.