### PR TITLE
#618 comment() implemented in Flow nodes

### DIFF
--- a/src/main/java/com/amihaiemil/eoyaml/ReadFlowSequence.java
+++ b/src/main/java/com/amihaiemil/eoyaml/ReadFlowSequence.java
@@ -141,7 +141,33 @@ final class ReadFlowSequence extends BaseYamlSequence {
 
     @Override
     public Comment comment() {
-        return new BuiltComment(this, "");
+        boolean documentComment = this.previous.number() < 0;
+        //@checkstyle LineLength (50 lines)
+        return new ReadComment(
+            new Backwards(
+                new FirstCommentFound(
+                    new Backwards(
+                        new Skip(
+                            this.all,
+                            line -> {
+                                final boolean skip;
+                                if(documentComment) {
+                                    skip = line.number() >= this.folded.number();
+                                } else {
+                                    skip = line.number() >= this.previous.number();
+                                }
+                                return skip;
+                            },
+                            line -> line.trimmed().startsWith("..."),
+                            line -> line.trimmed().startsWith("%"),
+                            line -> line.trimmed().startsWith("!!")
+                        )
+                    ),
+                    documentComment
+                )
+            ),
+            this
+        );
     }
 
     /**

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFlowMappingTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFlowMappingTestCase.java
@@ -30,8 +30,6 @@ package com.amihaiemil.eoyaml;
 import org.hamcrest.MatcherAssert;
 import org.hamcrest.Matchers;
 import org.junit.Test;
-import org.mockito.Mockito;
-
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -46,16 +44,50 @@ import java.util.Set;
 public final class ReadFlowMappingTestCase {
 
     /**
-     * YamlMapping in flow format has no comment.
+     * YamlMapping in flow format can return the document comment.
      */
     @Test
-    public void hasNoComment() {
+    public void hasDocumentComment() {
         final YamlMapping map = new ReadFlowMapping(
-            Mockito.mock(YamlLine.class)
+            new RtYamlLine("{a: b, c: d, e: f}", 2),
+            new RtYamlLine("---", 1),
+            new AllYamlLines(
+                Arrays.asList(
+                    new RtYamlLine("# this is a flow mapping document", 0),
+                    new RtYamlLine("---", 1),
+                    new RtYamlLine("{a: b, c: d, e: f}", 2)
+                )
+            )
         );
         MatcherAssert.assertThat(
             map.comment().value(),
-            Matchers.isEmptyString()
+            Matchers.equalTo("this is a flow mapping document")
+        );
+        MatcherAssert.assertThat(
+            map.comment().yamlNode(),
+            Matchers.is(map)
+        );
+    }
+
+    /**
+     * YamlMapping in flow format can return the comment referring to it.
+     */
+    @Test
+    public void hasOwnNodeComment() {
+        final YamlMapping map = new ReadFlowMapping(
+            new RtYamlLine("{a: {i: j}, c: d, e: f}", 2),
+            new RtYamlLine("flow:", 1),
+            new AllYamlLines(
+                Arrays.asList(
+                    new RtYamlLine("# this comment about the 'flow' map", 0),
+                    new RtYamlLine("flow:", 1),
+                    new RtYamlLine("  {a: {i: j}, c: d, e: f}", 2)
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            map.comment().value(),
+            Matchers.equalTo("this comment about the 'flow' map")
         );
         MatcherAssert.assertThat(
             map.comment().yamlNode(),

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFlowMappingTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFlowMappingTestCase.java
@@ -44,7 +44,7 @@ import java.util.Set;
 public final class ReadFlowMappingTestCase {
 
     /**
-     * YamlMapping in flow format can return the document comment.
+     * ReadFlowMapping can return the document comment.
      */
     @Test
     public void hasDocumentComment() {
@@ -70,7 +70,7 @@ public final class ReadFlowMappingTestCase {
     }
 
     /**
-     * YamlMapping in flow format can return the comment referring to it.
+     * ReadFlowMapping can return the comment referring to it.
      */
     @Test
     public void hasOwnNodeComment() {

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFlowSequenceTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFlowSequenceTestCase.java
@@ -46,18 +46,50 @@ import java.util.Iterator;
 public final class ReadFlowSequenceTestCase {
 
     /**
-     * Sequences in flow/json style have no comment.
+     * ReadFlowSequence can return the document comment.
      */
     @Test
-    public void hasNoComment() {
+    public void hasDocumentComment() {
         final YamlSequence seq = new ReadFlowSequence(
-            Mockito.mock(YamlLine.class),
-            Mockito.mock(YamlLine.class),
-            new AllYamlLines(new ArrayList<>())
+            new RtYamlLine("[{a: b}, {c: d}, {e: f}]", 2),
+            new RtYamlLine("---", 1),
+            new AllYamlLines(
+                Arrays.asList(
+                    new RtYamlLine("# this is a flow sequence document", 0),
+                    new RtYamlLine("---", 1),
+                    new RtYamlLine("[{a: b}, {c: d}, {e: f}]", 2)
+                )
+            )
         );
         MatcherAssert.assertThat(
             seq.comment().value(),
-            Matchers.isEmptyString()
+            Matchers.equalTo("this is a flow sequence document")
+        );
+        MatcherAssert.assertThat(
+            seq.comment().yamlNode(),
+            Matchers.is(seq)
+        );
+    }
+
+    /**
+     * ReadFlowMapping can return the comment referring to it.
+     */
+    @Test
+    public void hasOwnNodeComment() {
+        final YamlSequence seq = new ReadFlowSequence(
+            new RtYamlLine("[{a: b}, {c: d}, {e: f}]", 2),
+            new RtYamlLine("flow_seq:", 1),
+            new AllYamlLines(
+                Arrays.asList(
+                    new RtYamlLine("# this comment about the 'flow' seq", 0),
+                    new RtYamlLine("flow:", 1),
+                    new RtYamlLine("  [{a: b}, {c: d}, {e: f}]", 2)
+                )
+            )
+        );
+        MatcherAssert.assertThat(
+            seq.comment().value(),
+            Matchers.equalTo("this comment about the 'flow' seq")
         );
         MatcherAssert.assertThat(
             seq.comment().yamlNode(),

--- a/src/test/java/com/amihaiemil/eoyaml/ReadFlowSequenceTestCase.java
+++ b/src/test/java/com/amihaiemil/eoyaml/ReadFlowSequenceTestCase.java
@@ -32,6 +32,7 @@ import org.hamcrest.Matchers;
 import org.junit.Test;
 import org.mockito.Mockito;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Iterator;
@@ -50,7 +51,9 @@ public final class ReadFlowSequenceTestCase {
     @Test
     public void hasNoComment() {
         final YamlSequence seq = new ReadFlowSequence(
-            Mockito.mock(YamlLine.class)
+            Mockito.mock(YamlLine.class),
+            Mockito.mock(YamlLine.class),
+            new AllYamlLines(new ArrayList<>())
         );
         MatcherAssert.assertThat(
             seq.comment().value(),
@@ -68,7 +71,9 @@ public final class ReadFlowSequenceTestCase {
     @Test
     public void hasNoValues() {
         final YamlSequence seq = new ReadFlowSequence(
-            new RtYamlLine("[]", 0)
+            new RtYamlLine("[]", 0),
+            Mockito.mock(YamlLine.class),
+            new AllYamlLines(new ArrayList<>())
         );
         MatcherAssert.assertThat(
             seq.values(),
@@ -82,7 +87,9 @@ public final class ReadFlowSequenceTestCase {
     @Test
     public void hasOnlyScalars() {
         final YamlSequence seq = new ReadFlowSequence(
-            new RtYamlLine("[a, b, c, d:e]", 0)
+            new RtYamlLine("[a, b, c, d:e]", 0),
+            Mockito.mock(YamlLine.class),
+            new AllYamlLines(new ArrayList<>())
         );
         final Collection<YamlNode> values = seq.values();
         MatcherAssert.assertThat(values, Matchers.iterableWithSize(4));
@@ -111,7 +118,9 @@ public final class ReadFlowSequenceTestCase {
     @Test
     public void hasOnlySequences() {
         final YamlSequence seq = new ReadFlowSequence(
-            new RtYamlLine("[[a, b], [c,\"[a]\",'b]['], [d]]", 0)
+            new RtYamlLine("[[a, b], [c,\"[a]\",'b]['], [d]]", 0),
+            Mockito.mock(YamlLine.class),
+            new AllYamlLines(new ArrayList<>())
         );
         System.out.println(seq);
         MatcherAssert.assertThat(
@@ -161,7 +170,9 @@ public final class ReadFlowSequenceTestCase {
         final YamlSequence seq = new ReadFlowSequence(
             new RtYamlLine(
                 "[scalar, \"u][\", 'v}{', 'escalar', [a, b], other, [d]]", 0
-            )
+            ),
+            Mockito.mock(YamlLine.class),
+            new AllYamlLines(new ArrayList<>())
         );
         System.out.println(seq);
         MatcherAssert.assertThat(


### PR DESCRIPTION
PR for #618 
First flow nodes can now fetch their parent comment (comment referring to them) or the document comment if they are the only nodes in the file.